### PR TITLE
fix CToken admin role acceptance function

### DIFF
--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -1134,7 +1134,7 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
       */
     function _acceptAdmin() external returns (uint) {
         // Check caller is pendingAdmin and pendingAdmin ≠ address(0)
-        if (msg.sender != pendingAdmin || msg.sender == address(0)) {
+        if (msg.sender != pendingAdmin || pendingAdmin == address(0)) {
             return fail(Error.UNAUTHORIZED, FailureInfo.ACCEPT_ADMIN_PENDING_ADMIN_CHECK);
         }
 

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -1134,7 +1134,7 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
       */
     function _acceptAdmin() external returns (uint) {
         // Check caller is pendingAdmin and pendingAdmin ≠ address(0)
-        if (msg.sender != pendingAdmin || pendingAdmin == address(0)) {
+        if (msg.sender != pendingAdmin && pendingAdmin != address(0)) {
             return fail(Error.UNAUTHORIZED, FailureInfo.ACCEPT_ADMIN_PENDING_ADMIN_CHECK);
         }
 


### PR DESCRIPTION
This change fixes the behaviour of the `CToken#_acceptAdmin` function when the `pendingAdmin` variable is not yet set.