### PR TITLE
gas optimization for CToken.accrueInterest()

### DIFF
--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -36,6 +36,7 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
         initialExchangeRateMantissa = initialExchangeRateMantissa_;
         require(initialExchangeRateMantissa > 0, "initial exchange rate must be greater than zero.");
 
+
         // Set the comptroller
         uint err = _setComptroller(comptroller_);
         require(err == uint(Error.NO_ERROR), "setting comptroller failed");

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -415,7 +415,7 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
          *  borrowIndexNew = simpleInterestFactor * borrowIndex + borrowIndex
          *         
          *  for gas saving, if blockDelta == 0:
-         *  simpleInterestFactor = borrowRate * 0 = 0;
+         *  simpleInterestFactor = borrowRate * blockDelta = 0;
          *  interestAccumulated = simpleInterestFactor * totalBorrows = 0;
          *  totalBorrowsNew =  interestAccumulated + totalBorrows  = totalBorrows
          *  totalReservesNew = interestAccumulated * reserveFactor + totalReserves = totalReserves


### PR DESCRIPTION
        /*
         * Calculate the interest accumulated into borrows and reserves and the new index:
         *  simpleInterestFactor = borrowRate * blockDelta
         *  interestAccumulated = simpleInterestFactor * totalBorrows
         *  totalBorrowsNew = interestAccumulated + totalBorrows
         *  totalReservesNew = interestAccumulated * reserveFactor + totalReserves
         *  borrowIndexNew = simpleInterestFactor * borrowIndex + borrowIndex
         *         
         *  for gas saving, if blockDelta == 0:
         *  simpleInterestFactor = borrowRate * blockDelta = 0;
         *  interestAccumulated = simpleInterestFactor * totalBorrows = 0;
         *  totalBorrowsNew =  interestAccumulated + totalBorrows  = totalBorrows
         *  totalReservesNew = interestAccumulated * reserveFactor + totalReserves = totalReserves
         *  borrowIndexNew = simpleInterestFactor * borrowIndex + borrowIndex = borrowIndex
         * 
         */

If there are more than one transaction in a block,   accrueInterest()  would be called for many times.  if the call of accrueInterest() is not the first time  of  one block,  the calculation steps of some parameters could be  reduced in order to save gas.


