### PR TITLE
fixed: Timelock.sol constructor revert message

### DIFF
--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -25,7 +25,7 @@ contract Timelock {
 
     constructor(address admin_, uint delay_) public {
         require(delay_ >= MINIMUM_DELAY, "Timelock::constructor: Delay must exceed minimum delay.");
-        require(delay_ <= MAXIMUM_DELAY, "Timelock::setDelay: Delay must not exceed maximum delay.");
+        require(delay_ <= MAXIMUM_DELAY, "Timelock::constructor: Delay must not exceed maximum delay.");
 
         admin = admin_;
         delay = delay_;


### PR DESCRIPTION
In `Timelock.sol`'s constructor, I believe the second revert message should be fixed from `Timelock::setDelay: Delay must not exceed maximum delay.` to `Timelock::constructor: Delay must not exceed maximum delay.` to be consistent with the actual revert condition