### PR TITLE
Fix typo in Timelock constructor error message

### DIFF
--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -25,7 +25,7 @@ contract Timelock {
 
     constructor(address admin_, uint delay_) public {
         require(delay_ >= MINIMUM_DELAY, "Timelock::constructor: Delay must exceed minimum delay.");
-        require(delay_ <= MAXIMUM_DELAY, "Timelock::setDelay: Delay must not exceed maximum delay.");
+        require(delay_ <= MAXIMUM_DELAY, "Timelock::constructor: Delay must not exceed maximum delay.");
 
         admin = admin_;
         delay = delay_;


### PR DESCRIPTION
While going through Compound Timelock code to create @SushiSwap, I spotted a typo as fixed in this PR. It's not a critical issue, obviously, but worth fixing to avoid confusion (: