### PR TITLE
delete useless code

### DIFF
--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -159,9 +159,6 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
         require(msg.sender == proposal.proposer || comp.getPriorVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold, "GovernorBravo::cancel: proposer above threshold");
 
         proposal.canceled = true;
-        for (uint i = 0; i < proposal.targets.length; i++) {
-            timelock.cancelTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
-        }
 
         emit ProposalCanceled(proposalId);
     }


### PR DESCRIPTION
or
and   if(state(proposalId) >= ProposalState.Queued){
  for (uint i = 0; i < proposal.targets.length; i++) {
     timelock.cancelTransaction(...)
  }
}
because **proposal.eta** =0 when state(proposalId) < ProposalState.Queued