### PR TITLE
Adds a portion of liquidated collateral to CToken reserves

### DIFF
--- a/contracts/CEther.sol
+++ b/contracts/CEther.sol
@@ -107,6 +107,14 @@ contract CEther is CToken {
     }
 
     /**
+     * @notice The sender adds to reserves.
+     * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
+     */
+    function _addReserves() external payable returns (uint) {
+        return _addReservesInternal(msg.value);
+    }
+
+    /**
      * @notice Send Ether to CEther to mint
      */
     function () external payable {

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -1036,6 +1036,18 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
         return seizeInternal(msg.sender, liquidator, borrower, seizeTokens);
     }
 
+    struct SeizeInternalLocalVars {
+        MathError mathErr;
+        uint borrowerTokensNew;
+        uint liquidatorTokensNew;
+        uint liquidatorSeizeTokens;
+        uint protocolSeizeTokens;
+        uint protocolSeizeAmount;
+        uint exchangeRateMantissa;
+        uint totalReservesNew;
+        uint totalSupplyNew;
+    }
+
     /**
      * @notice Transfers collateral tokens (this market) to the liquidator.
      * @dev Called only during an in-kind liquidation, or by liquidateBorrow during the liquidation of another CToken.
@@ -1058,38 +1070,33 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
             return fail(Error.INVALID_ACCOUNT_PAIR, FailureInfo.LIQUIDATE_SEIZE_LIQUIDATOR_IS_BORROWER);
         }
 
-        MathError mathErr;
-        uint borrowerTokensNew;
-        uint liquidatorTokensNew;
-        uint liquidatorSeizeTokens;
-        uint protocolSeizeTokens;
-        uint protocolSeizeAmount;
-        uint exchangeRateMantissa;
-        uint totalReservesNew;
+        SeizeInternalLocalVars memory vars;
 
         /*
          * We calculate the new borrower and liquidator token balances, failing on underflow/overflow:
          *  borrowerTokensNew = accountTokens[borrower] - seizeTokens
          *  liquidatorTokensNew = accountTokens[liquidator] + seizeTokens
          */
-        (mathErr, borrowerTokensNew) = subUInt(accountTokens[borrower], seizeTokens);
-        if (mathErr != MathError.NO_ERROR) {
-            return failOpaque(Error.MATH_ERROR, FailureInfo.LIQUIDATE_SEIZE_BALANCE_DECREMENT_FAILED, uint(mathErr));
+        (vars.mathErr, vars.borrowerTokensNew) = subUInt(accountTokens[borrower], seizeTokens);
+        if (vars.mathErr != MathError.NO_ERROR) {
+            return failOpaque(Error.MATH_ERROR, FailureInfo.LIQUIDATE_SEIZE_BALANCE_DECREMENT_FAILED, uint(vars.mathErr));
         }
 
-        protocolSeizeTokens = mul_(seizeTokens, Exp({mantissa: protocolSeizeShareMantissa}));
-        liquidatorSeizeTokens = sub_(seizeTokens, protocolSeizeTokens);
+        vars.protocolSeizeTokens = mul_(seizeTokens, Exp({mantissa: protocolSeizeShareMantissa}));
+        vars.liquidatorSeizeTokens = sub_(seizeTokens, vars.protocolSeizeTokens);
 
-        (mathErr, exchangeRateMantissa) = exchangeRateStoredInternal();
-        require(mathErr == MathError.NO_ERROR, "exchange rate math error");
+        (vars.mathErr, vars.exchangeRateMantissa) = exchangeRateStoredInternal();
+        require(vars.mathErr == MathError.NO_ERROR, "exchange rate math error");
 
-        protocolSeizeAmount = mul_ScalarTruncate(Exp({mantissa: exchangeRateMantissa}), protocolSeizeTokens);
+        vars.protocolSeizeAmount = mul_ScalarTruncate(Exp({mantissa: vars.exchangeRateMantissa}), vars.protocolSeizeTokens);
 
-        totalReservesNew = add_(totalReserves, protocolSeizeAmount);
+        vars.totalReservesNew = add_(totalReserves, vars.protocolSeizeAmount);
+        vars.totalSupplyNew = sub_(totalSupply, vars.protocolSeizeTokens);
 
-        (mathErr, liquidatorTokensNew) = addUInt(accountTokens[liquidator], liquidatorSeizeTokens);
-        if (mathErr != MathError.NO_ERROR) {
-            return failOpaque(Error.MATH_ERROR, FailureInfo.LIQUIDATE_SEIZE_BALANCE_INCREMENT_FAILED, uint(mathErr));
+        vars.liquidatorTokensNew = add_(accountTokens[liquidator], vars.liquidatorSeizeTokens);
+        (vars.mathErr, vars.liquidatorTokensNew) = addUInt(accountTokens[liquidator], vars.liquidatorSeizeTokens);
+        if (vars.mathErr != MathError.NO_ERROR) {
+            return failOpaque(Error.MATH_ERROR, FailureInfo.LIQUIDATE_SEIZE_BALANCE_INCREMENT_FAILED, uint(vars.mathErr));
         }
 
         /////////////////////////
@@ -1097,13 +1104,14 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
         // (No safe failures beyond this point)
 
         /* We write the previously calculated values into storage */
-        totalReserves = totalReservesNew;
-        accountTokens[borrower] = borrowerTokensNew;
-        accountTokens[liquidator] = liquidatorTokensNew;
+        totalReserves = vars.totalReservesNew;
+        totalSupply = vars.totalSupplyNew;
+        accountTokens[borrower] = vars.borrowerTokensNew;
+        accountTokens[liquidator] = vars.liquidatorTokensNew;
 
         /* Emit a Transfer event */
         emit Transfer(borrower, liquidator, seizeTokens);
-        emit ReservesAdded(address(this), protocolSeizeAmount, totalReservesNew);
+        emit ReservesAdded(address(this), vars.protocolSeizeAmount, vars.totalReservesNew);
 
         /* We call the defense hook */
         // unused function

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -1093,7 +1093,6 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
         vars.totalReservesNew = add_(totalReserves, vars.protocolSeizeAmount);
         vars.totalSupplyNew = sub_(totalSupply, vars.protocolSeizeTokens);
 
-        vars.liquidatorTokensNew = add_(accountTokens[liquidator], vars.liquidatorSeizeTokens);
         (vars.mathErr, vars.liquidatorTokensNew) = addUInt(accountTokens[liquidator], vars.liquidatorSeizeTokens);
         if (vars.mathErr != MathError.NO_ERROR) {
             return failOpaque(Error.MATH_ERROR, FailureInfo.LIQUIDATE_SEIZE_BALANCE_INCREMENT_FAILED, uint(vars.mathErr));

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -1206,18 +1206,6 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
     }
 
     /**
-      * @notice sets a new protocol share of seize assets
-      * @dev Admin function to set a new protocolSeizeShareMantissa
-      * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
-      */
-    function _setProtocolSeizeShare(uint newProtocolSeizeShareMantissa) external nonReentrant returns (uint) {
-        require(msg.sender == admin, "Must be admin to set protocol seize share");
-        require(newProtocolSeizeShareMantissa < protocolSeizeShareMaxMantissa, "New protocol seize share higher than maximum");
-        
-        protocolSeizeShareMantissa = newProtocolSeizeShareMantissa;
-    }
-
-    /**
       * @notice Sets a new reserve factor for the protocol (*requires fresh interest accrual)
       * @dev Admin function to set a new reserve factor
       * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)

--- a/contracts/CTokenInterfaces.sol
+++ b/contracts/CTokenInterfaces.sol
@@ -115,6 +115,17 @@ contract CTokenStorage {
      * @notice Mapping of account addresses to outstanding borrow balances
      */
     mapping(address => BorrowSnapshot) internal accountBorrows;
+
+    /**
+     * @notice Share of seized collateral that is added to reserves
+     */
+    uint public protocolSeizeShareMantissa;
+
+    /**
+     * @notice Maximum fraction of interest that can be set aside for reserves
+     */
+    uint internal constant protocolSeizeShareMaxMantissa = 1e18;
+
 }
 
 contract CTokenInterface is CTokenStorage {

--- a/contracts/CTokenInterfaces.sol
+++ b/contracts/CTokenInterfaces.sol
@@ -119,7 +119,7 @@ contract CTokenStorage {
     /**
      * @notice Share of seized collateral that is added to reserves
      */
-    uint internal constant protocolSeizeShareMantissa = 28e16;
+    uint internal constant protocolSeizeShareMantissa = 2.8e16; //2.8%
 
 }
 

--- a/contracts/CTokenInterfaces.sol
+++ b/contracts/CTokenInterfaces.sol
@@ -119,12 +119,7 @@ contract CTokenStorage {
     /**
      * @notice Share of seized collateral that is added to reserves
      */
-    uint public protocolSeizeShareMantissa;
-
-    /**
-     * @notice Maximum fraction of interest that can be set aside for reserves
-     */
-    uint internal constant protocolSeizeShareMaxMantissa = 1e18;
+    uint internal constant protocolSeizeShareMantissa = 28e16;
 
 }
 

--- a/spec/scenario/Fee.scen
+++ b/spec/scenario/Fee.scen
@@ -66,8 +66,9 @@ Test "Should be able to liquidate fee token borrow"
     -- OK! should be ready to liquidate, so lets do that
     Prep Coburn 2e18 USDT cUSDT
     Liquidate Coburn "->" Torrey 0.1e18 cUSDT "Seizing" cZRX
-    -- 5.445e7 = 0.1 (amount liquidated) * 1.1 (liq discount) * .99 (fee) / 2e9 (exchange rate)
-    Assert Equal (Erc20 cZRX TokenBalance Coburn) 5.445e7
+    -- effective liquidation incentive after deducting protocolSeizeShare is 1.1 * (1-.028) = 1.0692
+    -- 5.29254e7 = 0.1e18 (amount liquidated) * 1.0692 (liq discount) * .99 (fee) / 2e9 (exchange rate)
+    Assert Equal (Erc20 cZRX TokenBalance Coburn) 5.29254e7
     Assert Equal (CToken cUSDT BorrowBalance Torrey) 1.881e18 -- 1.98 - (0.1 * .99) was liquidated
     Assert Equal (Erc20 USDT TokenBalance Coburn) 1.9e18
 

--- a/spec/scenario/InKindLiquidation.scen
+++ b/spec/scenario/InKindLiquidation.scen
@@ -140,8 +140,9 @@ Test "Proper In-Kind Liquidation"
     --
     -- And see what they are now
     Assert Equal (CToken cBAT ExchangeRate) 4e9 --- XXX: Verify this
-    Assert Equal (Erc20 cBAT TokenBalance Geoff) 49.45e9 -- 1:1 -> 1 x 2e18 x 1.1 ÷ 4e9 [exchange rate] = 0.55e9 -> Torrey
-    Assert Equal (Erc20 cBAT TokenBalance Torrey) 0.55e9 -- didn't have any beforehand
+    -- effective liquidation incentive after deducting protocolSeizeShare is 1.1 * (1-.028) = 1.0692
+    Assert Equal (Erc20 cBAT TokenBalance Geoff) 49.45e9 -- 1:1 -> 1 x 2e18 x 1.0692 ÷ 4e9 [exchange rate] = 0.55e9 -> Torrey
+    Assert Equal (Erc20 cBAT TokenBalance Torrey) 0.5346e9 -- didn't have any beforehand XXX
     Assert Equal (Erc20 BAT TokenBalance Torrey) 0e18 -- repaid
     Assert Equal (Erc20 BAT TokenBalance cBAT) 101e18 -- had 100e18, lent 1e18 to geoff, repaid 2
     Assert Equal (CToken cBAT BorrowBalanceStored Geoff) 99e18 -- less closed amount

--- a/spec/scenario/Seize.scen
+++ b/spec/scenario/Seize.scen
@@ -46,5 +46,6 @@ Test "Able to seize tokens with a malicious listed cToken"
     Mint Geoff 50e18 cZRX
     Assert Equal (Erc20 cZRX TokenBalance Geoff) 50e9
     Expect Changes (Erc20 cZRX TokenBalance Geoff) -1e9
-    Expect Changes (Erc20 cZRX TokenBalance Torrey) +1e9
+    -- effective liquidation reward is 1-.028 = 0.972 after protocolSeizeShare (liq incentive = 1)
+    Expect Changes (Erc20 cZRX TokenBalance Torrey) +0.972e9
     EvilSeize cEVL 1e9 cZRX seizer:Torrey seizee:Geoff

--- a/tests/Utils/Compound.js
+++ b/tests/Utils/Compound.js
@@ -354,16 +354,6 @@ async function getBalances(cTokens, accounts) {
   return balances;
 }
 
-async function adjustReserves(cToken, balances, delta) {
-  balances[cToken._address][cToken._address]["reserves"] = new BigNumber(balances[cToken._address][cToken._address]["reserves"]).plus(delta);
-  return balances;
-}
-
-async function adjustETHBalance(cToken, balances, delta) {
-  balances[cToken._address][cToken._address]["eth"] = new BigNumber(balances[cToken._address][cToken._address]["eth"]).plus(delta);
-  return balances;
-}
-
 async function adjustBalances(balances, deltas) {
   for (let delta of deltas) {
     let cToken, account, key, diff;
@@ -471,8 +461,6 @@ module.exports = {
   setEtherBalance,
   getBalances,
   adjustBalances,
-  adjustReserves,
-  adjustETHBalance,
 
   preApprove,
   quickMint,

--- a/tests/Utils/Compound.js
+++ b/tests/Utils/Compound.js
@@ -359,6 +359,11 @@ async function adjustReserves(cToken, balances, delta) {
   return balances;
 }
 
+async function adjustETHBalance(cToken, balances, delta) {
+  balances[cToken._address][cToken._address]["eth"] = new BigNumber(balances[cToken._address][cToken._address]["eth"]).plus(delta);
+  return balances;
+}
+
 async function adjustBalances(balances, deltas) {
   for (let delta of deltas) {
     let cToken, account, key, diff;
@@ -467,6 +472,7 @@ module.exports = {
   getBalances,
   adjustBalances,
   adjustReserves,
+  adjustETHBalance,
 
   preApprove,
   quickMint,

--- a/tests/Utils/Compound.js
+++ b/tests/Utils/Compound.js
@@ -354,6 +354,11 @@ async function getBalances(cTokens, accounts) {
   return balances;
 }
 
+async function adjustReserves(cToken, balances, delta) {
+  balances[cToken._address][cToken._address]["reserves"] = new BigNumber(balances[cToken._address][cToken._address]["reserves"]).plus(delta);
+  return balances;
+}
+
 async function adjustBalances(balances, deltas) {
   for (let delta of deltas) {
     let cToken, account, key, diff;
@@ -363,7 +368,6 @@ async function adjustBalances(balances, deltas) {
       ([cToken, key, diff] = delta);
       account = cToken._address;
     }
-
     balances[cToken._address][account][key] = new BigNumber(balances[cToken._address][account][key]).plus(diff);
   }
   return balances;
@@ -462,6 +466,7 @@ module.exports = {
   setEtherBalance,
   getBalances,
   adjustBalances,
+  adjustReserves,
 
   preApprove,
   quickMint,


### PR DESCRIPTION
Introduces `protocolSeizeShare`, the percentage of a liquidated account's seized collateral that will be added to reserves. This comes at the expense of the liquidator, who would normally earn the entire liquidated collateral amount.

Also adds `addReserves` to CEther, allowing this change to be implemented on CEther also. 