### PR TITLE
Support cLINK

### DIFF
--- a/networks/mainnet-abi.json
+++ b/networks/mainnet-abi.json
@@ -1,3977 +1,4 @@
 {
-    "GovernorBravo": [
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "timelock_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "comp_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "admin_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "votingPeriod_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "votingDelay_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "proposalThreshold_",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldImplementation",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newImplementation",
-                    "type": "address"
-                }
-            ],
-            "name": "NewImplementation",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldPendingAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPendingAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "id",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ProposalCanceled",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "id",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "proposer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address[]",
-                    "name": "targets",
-                    "type": "address[]"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256[]",
-                    "name": "values",
-                    "type": "uint256[]"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "string[]",
-                    "name": "signatures",
-                    "type": "string[]"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "bytes[]",
-                    "name": "calldatas",
-                    "type": "bytes[]"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "startBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "endBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "description",
-                    "type": "string"
-                }
-            ],
-            "name": "ProposalCreated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "id",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ProposalExecuted",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "id",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "eta",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ProposalQueued",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldProposalThreshold",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newProposalThreshold",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ProposalThresholdSet",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "voter",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "proposalId",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint8",
-                    "name": "support",
-                    "type": "uint8"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "votes",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "reason",
-                    "type": "string"
-                }
-            ],
-            "name": "VoteCast",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldVotingDelay",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newVotingDelay",
-                    "type": "uint256"
-                }
-            ],
-            "name": "VotingDelaySet",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldVotingPeriod",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newVotingPeriod",
-                    "type": "uint256"
-                }
-            ],
-            "name": "VotingPeriodSet",
-            "type": "event"
-        },
-        {
-            "payable": true,
-            "stateMutability": "payable",
-            "type": "fallback"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                }
-            ],
-            "name": "_setImplementation",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "implementation",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-          "constant": false,
-          "inputs": [
-            {
-              "internalType": "address[]",
-              "name": "targets",
-              "type": "address[]"
-            },
-            {
-              "internalType": "uint256[]",
-              "name": "values",
-              "type": "uint256[]"
-            },
-            {
-              "internalType": "string[]",
-              "name": "signatures",
-              "type": "string[]"
-            },
-            {
-              "internalType": "bytes[]",
-              "name": "calldatas",
-              "type": "bytes[]"
-            },
-            {
-              "internalType": "string",
-              "name": "description",
-              "type": "string"
-            }
-          ],
-          "name": "propose",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "payable": false,
-          "stateMutability": "nonpayable",
-          "type": "function",
-          "signature": "0xda95691a"
-        },
-        {
-          "constant": false,
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "proposalId",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "support",
-              "type": "uint8"
-            },
-            {
-              "internalType": "string",
-              "name": "reason",
-              "type": "string"
-            }
-          ],
-          "name": "castVoteWithReason",
-          "outputs": [],
-          "payable": false,
-          "stateMutability": "nonpayable",
-          "type": "function",
-          "signature": "0x15373e3d"
-        }
-    ],
-    "cWBTC2": [
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "underlying_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "comptroller_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "interestRateModel_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "initialExchangeRateMantissa_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "string",
-                    "name": "name_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "string",
-                    "name": "symbol_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "decimals_",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "address payable",
-                    "name": "admin_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "becomeImplementationData",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "cashPrior",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "interestAccumulated",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "borrowIndex",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "AccrueInterest",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Borrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "error",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "info",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "detail",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Failure",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "LiquidateBorrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "mintAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "mintTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Mint",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "oldComptroller",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "NewComptroller",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldImplementation",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newImplementation",
-                    "type": "address"
-                }
-            ],
-            "name": "NewImplementation",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "contract InterestRateModel",
-                    "name": "oldInterestRateModel",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "contract InterestRateModel",
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "NewMarketInterestRateModel",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldPendingAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPendingAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldReserveFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewReserveFactor",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "redeemer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Redeem",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "payer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "RepayBorrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "benefactor",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "addAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTotalReserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ReservesAdded",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "admin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTotalReserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ReservesReduced",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "from",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event"
-        },
-        {
-            "payable": true,
-            "stateMutability": "payable",
-            "type": "fallback"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "_acceptAdmin",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "addAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_addReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_reduceReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "_setComptroller",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bool",
-                    "name": "allowResign",
-                    "type": "bool"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "becomeImplementationData",
-                    "type": "bytes"
-                }
-            ],
-            "name": "_setImplementation",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "_setInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "_setPendingAdmin",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setReserveFactor",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "accrualBlockNumber",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "accrueInterest",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOfUnderlying",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceStored",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowIndex",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "comptroller",
-            "outputs": [
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "delegateToImplementation",
-            "outputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "delegateToViewImplementation",
-            "outputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "exchangeRateCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "exchangeRateStored",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountSnapshot",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "getCash",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "implementation",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "interestRateModel",
-            "outputs": [
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isCToken",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "contract CTokenInterface",
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                }
-            ],
-            "name": "liquidateBorrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "mintAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeem",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeemUnderlying",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrowBehalf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "reserveFactorMantissa",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "seize",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "supplyRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract EIP20NonStandardInterface",
-                    "name": "token",
-                    "type": "address"
-                }
-            ],
-            "name": "sweepToken",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalBorrows",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "totalBorrowsCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "underlying",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        }
-    ],
-    "wbtc2_irm": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jumpMultiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                }
-            ],
-            "name": "updateJumpRateModel",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function"
-        }
-    ],
-    "cCOMP": [
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "underlying_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "comptroller_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "interestRateModel_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "initialExchangeRateMantissa_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "string",
-                    "name": "name_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "string",
-                    "name": "symbol_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "decimals_",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "address payable",
-                    "name": "admin_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "becomeImplementationData",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "cashPrior",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "interestAccumulated",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "borrowIndex",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "AccrueInterest",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Borrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "error",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "info",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "detail",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Failure",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "LiquidateBorrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "mintAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "mintTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Mint",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "oldComptroller",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "NewComptroller",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldImplementation",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newImplementation",
-                    "type": "address"
-                }
-            ],
-            "name": "NewImplementation",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "contract InterestRateModel",
-                    "name": "oldInterestRateModel",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "contract InterestRateModel",
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "NewMarketInterestRateModel",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "oldPendingAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPendingAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldReserveFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewReserveFactor",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "redeemer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Redeem",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "payer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "RepayBorrow",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "benefactor",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "addAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTotalReserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ReservesAdded",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "admin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTotalReserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ReservesReduced",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "from",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event"
-        },
-        {
-            "payable": true,
-            "stateMutability": "payable",
-            "type": "fallback"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "_acceptAdmin",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "addAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_addReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_reduceReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "_setComptroller",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "implementation_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bool",
-                    "name": "allowResign",
-                    "type": "bool"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "becomeImplementationData",
-                    "type": "bytes"
-                }
-            ],
-            "name": "_setImplementation",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "_setInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "_setPendingAdmin",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setReserveFactor",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "accrualBlockNumber",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "accrueInterest",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOfUnderlying",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceStored",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowIndex",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "comptroller",
-            "outputs": [
-                {
-                    "internalType": "contract ComptrollerInterface",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "delegateToImplementation",
-            "outputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "delegateToViewImplementation",
-            "outputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "",
-                    "type": "bytes"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "exchangeRateCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "exchangeRateStored",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountSnapshot",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "getCash",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "implementation",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "interestRateModel",
-            "outputs": [
-                {
-                    "internalType": "contract InterestRateModel",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isCToken",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "contract CTokenInterface",
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                }
-            ],
-            "name": "liquidateBorrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "mintAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "internalType": "address payable",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeem",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeemUnderlying",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrow",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrowBehalf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "reserveFactorMantissa",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "seize",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "supplyRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalBorrows",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "totalBorrowsCurrent",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalReserves",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "underlying",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        }
-    ],
-    "IRM_COMP_Updateable": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jumpMultiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                }
-            ],
-            "name": "updateJumpRateModel",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function"
-        }
-    ],
     "cUSDC": [
         {
             "constant": true,
@@ -5906,6 +1933,811 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ],
+    "PriceFeed": [
+        {
+            "inputs": [
+                {
+                    "internalType": "contract OpenOraclePriceData",
+                    "name": "priceData_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "reporter_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "anchorToleranceMantissa_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "anchorPeriod_",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig[]",
+                    "name": "configs",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "anchorPrice",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldTimestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTimestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AnchorPriceUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reporter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "anchor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PriceGuarded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "price",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PriceUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "reporter",
+                    "type": "address"
+                }
+            ],
+            "name": "ReporterInvalidated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "symbolHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldTimestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTimestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldPrice",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newPrice",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UniswapWindowUpdated",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "anchorPeriod",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "ethBaseUnit",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "expScale",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "i",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getTokenConfig",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "getTokenConfigByCToken",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                }
+            ],
+            "name": "getTokenConfigBySymbol",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "symbolHash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getTokenConfigBySymbolHash",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "underlying",
+                    "type": "address"
+                }
+            ],
+            "name": "getTokenConfigByUnderlying",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlying",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "symbolHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "baseUnit",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum UniswapConfig.PriceSource",
+                            "name": "priceSource",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "fixedPrice",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "uniswapMarket",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isUniswapReversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct UniswapConfig.TokenConfig",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "getUnderlyingPrice",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "message",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "invalidateReporter",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "lowerBoundAnchorRatio",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "maxTokens",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "newObservations",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "acc",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "numTokens",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "oldObservations",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "acc",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "messages",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "bytes[]",
+                    "name": "signatures",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "string[]",
+                    "name": "symbols",
+                    "type": "string[]"
+                }
+            ],
+            "name": "postPrices",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                }
+            ],
+            "name": "price",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "priceData",
+            "outputs": [
+                {
+                    "internalType": "contract OpenOraclePriceData",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "prices",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "reporter",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "reporterInvalidated",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "message",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "source",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "upperBoundAnchorRatio",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
             "type": "function"
         }
     ],
@@ -8777,29 +5609,860 @@
             "signature": "0x6f307dc3"
         }
     ],
-    "UNI": [
+    "CompoundLens": [
         {
+            "constant": false,
             "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "cTokenBalances",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "balanceOf",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "borrowBalanceCurrent",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "balanceOfUnderlying",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenBalance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenAllowance",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenBalances",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xbdf950c9"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "cTokenBalancesAll",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "balanceOf",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "borrowBalanceCurrent",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "balanceOfUnderlying",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenBalance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenAllowance",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenBalances[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x0972bf8b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "cTokenMetadata",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "exchangeRateCurrent",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "supplyRatePerBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "borrowRatePerBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "reserveFactorMantissa",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalBorrows",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalReserves",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalSupply",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalCash",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isListed",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "collateralFactorMantissa",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlyingAssetAddress",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "cTokenDecimals",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "underlyingDecimals",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenMetadata",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x158eca8b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "cTokenMetadataAll",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "exchangeRateCurrent",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "supplyRatePerBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "borrowRatePerBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "reserveFactorMantissa",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalBorrows",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalReserves",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalSupply",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalCash",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isListed",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "collateralFactorMantissa",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "underlyingAssetAddress",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "cTokenDecimals",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "underlyingDecimals",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenMetadata[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4b70d84b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "cTokenUnderlyingPrice",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "underlyingPrice",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenUnderlyingPrice",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xc5ae5934"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "cTokenUnderlyingPriceAll",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "cToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "underlyingPrice",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CTokenUnderlyingPrice[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x2b2d5ed6"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract Comptroller",
+                    "name": "comptroller",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAccountLimits",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "contract CToken[]",
+                            "name": "markets",
+                            "type": "address[]"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "liquidity",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "shortfall",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.AccountLimits",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x7dd8f6d9"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "contract Comp",
+                    "name": "comp",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getCompBalanceMetadata",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "balance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "votes",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "delegate",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CompBalanceMetadata",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x416405d7"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract Comp",
+                    "name": "comp",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract Comptroller",
+                    "name": "comptroller",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getCompBalanceMetadataExt",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "balance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "votes",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "delegate",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "allocated",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CompBalanceMetadataExt",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "contract Comp",
+                    "name": "comp",
+                    "type": "address"
+                },
                 {
                     "internalType": "address",
                     "name": "account",
                     "type": "address"
                 },
                 {
+                    "internalType": "uint32[]",
+                    "name": "blockNumbers",
+                    "type": "uint32[]"
+                }
+            ],
+            "name": "getCompVotes",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "blockNumber",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "votes",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.CompVotes[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x59564219"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "contract GovernorAlpha",
+                    "name": "governor",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "proposalIds",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "getGovProposals",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "proposalId",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "proposer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "eta",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address[]",
+                            "name": "targets",
+                            "type": "address[]"
+                        },
+                        {
+                            "internalType": "uint256[]",
+                            "name": "values",
+                            "type": "uint256[]"
+                        },
+                        {
+                            "internalType": "string[]",
+                            "name": "signatures",
+                            "type": "string[]"
+                        },
+                        {
+                            "internalType": "bytes[]",
+                            "name": "calldatas",
+                            "type": "bytes[]"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "forVotes",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "againstVotes",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "canceled",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "executed",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.GovProposal[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x96994869"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "contract GovernorAlpha",
+                    "name": "governor",
+                    "type": "address"
+                },
+                {
                     "internalType": "address",
-                    "name": "minter_",
+                    "name": "voter",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "proposalIds",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "getGovReceipts",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "proposalId",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "hasVoted",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "support",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "uint96",
+                            "name": "votes",
+                            "type": "uint96"
+                        }
+                    ],
+                    "internalType": "struct CompoundLens.GovReceipt[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x995ed99f"
+        }
+    ],
+    "CrowdProposalFactory": [
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "comp_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "governor_",
                     "type": "address"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "mintingAllowedAfter_",
+                    "name": "compStakeAmount_",
                     "type": "uint256"
                 }
             ],
-            "payable": false,
             "stateMutability": "nonpayable",
             "type": "constructor"
         },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proposal",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "author",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "CrowdProposalCreated",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "comp",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "compStakeAmount",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "createCrowdProposal",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "governor",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ],
+    "DAI": [
         {
             "anonymous": false,
             "inputs": [
@@ -8823,76 +6486,8 @@
                 }
             ],
             "name": "Approval",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "delegator",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "fromDelegate",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "toDelegate",
-                    "type": "address"
-                }
-            ],
-            "name": "DelegateChanged",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "delegate",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "previousBalance",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newBalance",
-                    "type": "uint256"
-                }
-            ],
-            "name": "DelegateVotesChanged",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "newMinter",
-                    "type": "address"
-                }
-            ],
-            "name": "MinterChanged",
-            "type": "event"
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
         },
         {
             "anonymous": false,
@@ -8917,374 +6512,8 @@
                 }
             ],
             "name": "Transfer",
-            "type": "event"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "DELEGATION_TYPEHASH",
-            "outputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "DOMAIN_TYPEHASH",
-            "outputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "PERMIT_TYPEHASH",
-            "outputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "rawAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint32",
-                    "name": "",
-                    "type": "uint32"
-                }
-            ],
-            "name": "checkpoints",
-            "outputs": [
-                {
-                    "internalType": "uint32",
-                    "name": "fromBlock",
-                    "type": "uint32"
-                },
-                {
-                    "internalType": "uint96",
-                    "name": "votes",
-                    "type": "uint96"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "delegatee",
-                    "type": "address"
-                }
-            ],
-            "name": "delegate",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "delegatee",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "nonce",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "expiry",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "v",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "bytes32",
-                    "name": "r",
-                    "type": "bytes32"
-                },
-                {
-                    "internalType": "bytes32",
-                    "name": "s",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "delegateBySig",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "delegates",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getCurrentVotes",
-            "outputs": [
-                {
-                    "internalType": "uint96",
-                    "name": "",
-                    "type": "uint96"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "blockNumber",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getPriorVotes",
-            "outputs": [
-                {
-                    "internalType": "uint96",
-                    "name": "",
-                    "type": "uint96"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "minimumTimeBetweenMints",
-            "outputs": [
-                {
-                    "internalType": "uint32",
-                    "name": "",
-                    "type": "uint32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "rawAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "mintCap",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "minter",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "mintingAllowedAfter",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
         },
         {
             "constant": true,
@@ -9299,109 +6528,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "nonces",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "numCheckpoints",
-            "outputs": [
-                {
-                    "internalType": "uint32",
-                    "name": "",
-                    "type": "uint32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "rawAmount",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "deadline",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "v",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "bytes32",
-                    "name": "r",
-                    "type": "bytes32"
-                },
-                {
-                    "internalType": "bytes32",
-                    "name": "s",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "permit",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "minter_",
-                    "type": "address"
-                }
-            ],
-            "name": "setMinter",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x06fdde03"
         },
         {
             "constant": true,
@@ -9416,7 +6544,24 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x95d89b41"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x313ce567"
         },
         {
             "constant": true,
@@ -9431,7 +6576,30 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x18160ddd"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "balance",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x70a08231"
         },
         {
             "constant": false,
@@ -9443,7 +6611,7 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "rawAmount",
+                    "name": "amount",
                     "type": "uint256"
                 }
             ],
@@ -9451,13 +6619,14 @@
             "outputs": [
                 {
                     "internalType": "bool",
-                    "name": "",
+                    "name": "success",
                     "type": "bool"
                 }
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xa9059cbb"
         },
         {
             "constant": false,
@@ -9474,7 +6643,7 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "rawAmount",
+                    "name": "amount",
                     "type": "uint256"
                 }
             ],
@@ -9482,13 +6651,1147 @@
             "outputs": [
                 {
                     "internalType": "bool",
-                    "name": "",
+                    "name": "success",
                     "type": "bool"
                 }
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x23b872dd"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "success",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x095ea7b3"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "remaining",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdd62ed3e"
+        }
+    ],
+    "StdComptroller": [
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isComptroller",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x007e3dd2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "name": "borrowerIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1ededc91"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrowAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x24008a62"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x26782247"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setCloseFactor",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x317b0b77"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "unitroller",
+                    "type": "address"
+                },
+                {
+                    "name": "_oracle",
+                    "type": "address"
+                },
+                {
+                    "name": "_closeFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "name": "_maxAssets",
+                    "type": "uint256"
+                },
+                {
+                    "name": "reinitializing",
+                    "type": "bool"
+                }
+            ],
+            "name": "_become",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x32000e00"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mintVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x41c728b9"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateBorrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x47ef3b3b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "liquidationIncentiveMantissa",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x4ada90af"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "name": "mintAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mintAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4ef4c3e1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setLiquidationIncentive",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4fd42e17"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeemVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x51dff989"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPriceOracle",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x55ee1fe1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x5c778605"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAccountLiquidity",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x5ec88c79"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateBorrowAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x5fc7e71e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "transferTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6a56947e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "seizeVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6d35bf91"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "oracle",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x7dc0d1d0"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "markets",
+            "outputs": [
+                {
+                    "name": "isListed",
+                    "type": "bool"
+                },
+                {
+                    "name": "collateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8e8f294b"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "checkMembership",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x929fe9a1"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "maxAssets",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x94b2294b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "_supportMarket",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xa76b3fda"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAssetsIn",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xabfceffc"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "comptrollerImplementation",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xbb82aa5e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "transferTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xbdcdc258"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "enterMarkets",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xc2998238"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateCalculateSeizeTokens",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xc488847b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "seizeAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd02f7351"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newMaxAssets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setMaxAssets",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd9226ced"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrowAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xda3d454c"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "accountAssets",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdce15449"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingComptrollerImplementation",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdcfbc0c7"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setCollateralFactor",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe4028eee"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "closeFactorMantissa",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xe8755446"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeemAllowed",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xeabe7d91"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "cTokenAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "exitMarket",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xede4edd0"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "admin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf851a440"
+        },
+        {
+            "inputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketListed",
+            "type": "event",
+            "signature": "0xcf583bb0c569eb967f806b11601c4cb93c10310485c67add5f8362c2f212321f"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketEntered",
+            "type": "event",
+            "signature": "0x3ab23ab0d51cccc0c3085aec51f99228625aa1a922b3a8ca89a26b0f2027a1a5"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketExited",
+            "type": "event",
+            "signature": "0xe699a64c18b07ac5b7301aa273f36a2287239eb9501d81950672794afba29a0d"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldCloseFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCloseFactor",
+            "type": "event",
+            "signature": "0x3b9670cf975d26958e754b57098eaa2ac914d8d2a31b83257997b9f346110fd9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "oldCollateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCollateralFactor",
+            "type": "event",
+            "signature": "0x70483e6592cd5182d45ac970e05bc62cdcc90e9d8ef2c2dbe686cf383bcd7fc5"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewLiquidationIncentive",
+            "type": "event",
+            "signature": "0xaeba5a6c40a8ac138134bff1aaa65debf25971188a58804bad717f82f0ec1316"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldMaxAssets",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newMaxAssets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewMaxAssets",
+            "type": "event",
+            "signature": "0x7093cf1eb653f749c3ff531d6df7f92764536a7fa0d13530cd26e070780c32ea"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPriceOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPriceOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event",
+            "signature": "0xd52b2b9b7e9ee655fcb95d2e5b9e0c9f69e7ef2b8e9d2d0ea78402d576d22e22"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
         }
     ],
     "cUNI": [
@@ -11021,2200 +9324,6 @@
             "stateMutability": "view",
             "type": "function",
             "signature": "0x6f307dc3"
-        }
-    ],
-    "CompoundLens": [
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken",
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address payable",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "cTokenBalances",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "balanceOf",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "borrowBalanceCurrent",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "balanceOfUnderlying",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenBalance",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenAllowance",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenBalances",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xbdf950c9"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken[]",
-                    "name": "cTokens",
-                    "type": "address[]"
-                },
-                {
-                    "internalType": "address payable",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "cTokenBalancesAll",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "balanceOf",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "borrowBalanceCurrent",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "balanceOfUnderlying",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenBalance",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenAllowance",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenBalances[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x0972bf8b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken",
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "cTokenMetadata",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "exchangeRateCurrent",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "supplyRatePerBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "borrowRatePerBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "reserveFactorMantissa",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalBorrows",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalReserves",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalSupply",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalCash",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isListed",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "collateralFactorMantissa",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlyingAssetAddress",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "cTokenDecimals",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "underlyingDecimals",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenMetadata",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x158eca8b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken[]",
-                    "name": "cTokens",
-                    "type": "address[]"
-                }
-            ],
-            "name": "cTokenMetadataAll",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "exchangeRateCurrent",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "supplyRatePerBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "borrowRatePerBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "reserveFactorMantissa",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalBorrows",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalReserves",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalSupply",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "totalCash",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isListed",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "collateralFactorMantissa",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlyingAssetAddress",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "cTokenDecimals",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "underlyingDecimals",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenMetadata[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x4b70d84b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken",
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "cTokenUnderlyingPrice",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "underlyingPrice",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenUnderlyingPrice",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xc5ae5934"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract CToken[]",
-                    "name": "cTokens",
-                    "type": "address[]"
-                }
-            ],
-            "name": "cTokenUnderlyingPriceAll",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "underlyingPrice",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CTokenUnderlyingPrice[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x2b2d5ed6"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract Comptroller",
-                    "name": "comptroller",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountLimits",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "contract CToken[]",
-                            "name": "markets",
-                            "type": "address[]"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "liquidity",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "shortfall",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.AccountLimits",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x7dd8f6d9"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "contract Comp",
-                    "name": "comp",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getCompBalanceMetadata",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "balance",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "votes",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "delegate",
-                            "type": "address"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CompBalanceMetadata",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x416405d7"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract Comp",
-                    "name": "comp",
-                    "type": "address"
-                },
-                {
-                    "internalType": "contract Comptroller",
-                    "name": "comptroller",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getCompBalanceMetadataExt",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "balance",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "votes",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "delegate",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "allocated",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CompBalanceMetadataExt",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "contract Comp",
-                    "name": "comp",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint32[]",
-                    "name": "blockNumbers",
-                    "type": "uint32[]"
-                }
-            ],
-            "name": "getCompVotes",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "blockNumber",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "votes",
-                            "type": "uint256"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.CompVotes[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x59564219"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "contract GovernorAlpha",
-                    "name": "governor",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256[]",
-                    "name": "proposalIds",
-                    "type": "uint256[]"
-                }
-            ],
-            "name": "getGovProposals",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "proposalId",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "proposer",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "eta",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address[]",
-                            "name": "targets",
-                            "type": "address[]"
-                        },
-                        {
-                            "internalType": "uint256[]",
-                            "name": "values",
-                            "type": "uint256[]"
-                        },
-                        {
-                            "internalType": "string[]",
-                            "name": "signatures",
-                            "type": "string[]"
-                        },
-                        {
-                            "internalType": "bytes[]",
-                            "name": "calldatas",
-                            "type": "bytes[]"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "startBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "endBlock",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "forVotes",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "againstVotes",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "canceled",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "executed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.GovProposal[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x96994869"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "contract GovernorAlpha",
-                    "name": "governor",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "voter",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256[]",
-                    "name": "proposalIds",
-                    "type": "uint256[]"
-                }
-            ],
-            "name": "getGovReceipts",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "proposalId",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "hasVoted",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "support",
-                            "type": "bool"
-                        },
-                        {
-                            "internalType": "uint96",
-                            "name": "votes",
-                            "type": "uint96"
-                        }
-                    ],
-                    "internalType": "struct CompoundLens.GovReceipt[]",
-                    "name": "",
-                    "type": "tuple[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x995ed99f"
-        },
-        {
-          "constant": true,
-          "inputs": [
-            {
-              "internalType": "contract GovernorBravo",
-              "name": "governor",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256[]",
-              "name": "proposalIds",
-              "type": "uint256[]"
-            }
-          ],
-          "name": "getGovBravoProposals",
-          "outputs": [
-            {
-              "components": [
-                {
-                  "internalType": "uint256",
-                  "name": "proposalId",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "address",
-                  "name": "proposer",
-                  "type": "address"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "eta",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "address[]",
-                  "name": "targets",
-                  "type": "address[]"
-                },
-                {
-                  "internalType": "uint256[]",
-                  "name": "values",
-                  "type": "uint256[]"
-                },
-                {
-                  "internalType": "string[]",
-                  "name": "signatures",
-                  "type": "string[]"
-                },
-                {
-                  "internalType": "bytes[]",
-                  "name": "calldatas",
-                  "type": "bytes[]"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "startBlock",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "endBlock",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "forVotes",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "againstVotes",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "abstainVotes",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bool",
-                  "name": "canceled",
-                  "type": "bool"
-                },
-                {
-                  "internalType": "bool",
-                  "name": "executed",
-                  "type": "bool"
-                }
-              ],
-              "internalType": "struct CompoundLens.GovBravoProposal[]",
-              "name": "",
-              "type": "tuple[]"
-            }
-          ],
-          "payable": false,
-          "stateMutability": "view",
-          "type": "function",
-          "signature": "0x96994869"
-        },
-        {
-          "constant": true,
-          "inputs": [
-            {
-              "internalType": "contract GovernorBravo",
-              "name": "governor",
-              "type": "address"
-            },
-            {
-              "internalType": "address",
-              "name": "voter",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256[]",
-              "name": "proposalIds",
-              "type": "uint256[]"
-            }
-          ],
-          "name": "getGovBravoReceipts",
-          "outputs": [
-            {
-              "components": [
-                {
-                  "internalType": "uint256",
-                  "name": "proposalId",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bool",
-                  "name": "hasVoted",
-                  "type": "bool"
-                },
-                {
-                  "internalType": "uint8",
-                  "name": "support",
-                  "type": "uint8"
-                },
-                {
-                  "internalType": "uint96",
-                  "name": "votes",
-                  "type": "uint96"
-                }
-              ],
-              "internalType": "struct CompoundLens.GovBravoReceipt[]",
-              "name": "",
-              "type": "tuple[]"
-            }
-          ],
-          "payable": false,
-          "stateMutability": "view",
-          "type": "function",
-          "signature": "0x995ed99f"
-        }
-    ],
-    "DAI": [
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event",
-            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "from",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event",
-            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x06fdde03"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x95d89b41"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x313ce567"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x18160ddd"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "balance",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x70a08231"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "success",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xa9059cbb"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "success",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x23b872dd"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "success",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x095ea7b3"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "remaining",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xdd62ed3e"
-        }
-    ],
-    "StdComptroller": [
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isComptroller",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x007e3dd2"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "payer",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "name": "borrowerIndex",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrowVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x1ededc91"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "payer",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrowAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x24008a62"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x26782247"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newCloseFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setCloseFactor",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x317b0b77"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "unitroller",
-                    "type": "address"
-                },
-                {
-                    "name": "_oracle",
-                    "type": "address"
-                },
-                {
-                    "name": "_closeFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "name": "_maxAssets",
-                    "type": "uint256"
-                },
-                {
-                    "name": "reinitializing",
-                    "type": "bool"
-                }
-            ],
-            "name": "_become",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x32000e00"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "name": "mintAmount",
-                    "type": "uint256"
-                },
-                {
-                    "name": "mintTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mintVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x41c728b9"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokenBorrowed",
-                    "type": "address"
-                },
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "liquidateBorrowVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x47ef3b3b"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "liquidationIncentiveMantissa",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x4ada90af"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "name": "mintAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mintAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x4ef4c3e1"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newLiquidationIncentiveMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setLiquidationIncentive",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x4fd42e17"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "redeemer",
-                    "type": "address"
-                },
-                {
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                },
-                {
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeemVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x51dff989"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newOracle",
-                    "type": "address"
-                }
-            ],
-            "name": "_setPriceOracle",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x55ee1fe1"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrowVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x5c778605"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountLiquidity",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x5ec88c79"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokenBorrowed",
-                    "type": "address"
-                },
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "liquidateBorrowAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x5fc7e71e"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "transferTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x6a56947e"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "cTokenBorrowed",
-                    "type": "address"
-                },
-                {
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "seizeVerify",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x6d35bf91"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "oracle",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x7dc0d1d0"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "markets",
-            "outputs": [
-                {
-                    "name": "isListed",
-                    "type": "bool"
-                },
-                {
-                    "name": "collateralFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8e8f294b"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "checkMembership",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x929fe9a1"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "maxAssets",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x94b2294b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "_supportMarket",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xa76b3fda"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAssetsIn",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xabfceffc"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "comptrollerImplementation",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xbb82aa5e"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "transferTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xbdcdc258"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokens",
-                    "type": "address[]"
-                }
-            ],
-            "name": "enterMarkets",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256[]"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xc2998238"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "cTokenBorrowed",
-                    "type": "address"
-                },
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "liquidateCalculateSeizeTokens",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xc488847b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "cTokenBorrowed",
-                    "type": "address"
-                },
-                {
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "seizeAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xd02f7351"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newMaxAssets",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setMaxAssets",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xd9226ced"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrowAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xda3d454c"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "name": "accountAssets",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xdce15449"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingComptrollerImplementation",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xdcfbc0c7"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "newCollateralFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setCollateralFactor",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xe4028eee"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "closeFactorMantissa",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xe8755446"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "name": "redeemer",
-                    "type": "address"
-                },
-                {
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeemAllowed",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xeabe7d91"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "cTokenAddress",
-                    "type": "address"
-                }
-            ],
-            "name": "exitMarket",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xede4edd0"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf851a440"
-        },
-        {
-            "inputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "MarketListed",
-            "type": "event",
-            "signature": "0xcf583bb0c569eb967f806b11601c4cb93c10310485c67add5f8362c2f212321f"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "MarketEntered",
-            "type": "event",
-            "signature": "0x3ab23ab0d51cccc0c3085aec51f99228625aa1a922b3a8ca89a26b0f2027a1a5"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "MarketExited",
-            "type": "event",
-            "signature": "0xe699a64c18b07ac5b7301aa273f36a2287239eb9501d81950672794afba29a0d"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldCloseFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newCloseFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewCloseFactor",
-            "type": "event",
-            "signature": "0x3b9670cf975d26958e754b57098eaa2ac914d8d2a31b83257997b9f346110fd9"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "oldCollateralFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newCollateralFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewCollateralFactor",
-            "type": "event",
-            "signature": "0x70483e6592cd5182d45ac970e05bc62cdcc90e9d8ef2c2dbe686cf383bcd7fc5"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldLiquidationIncentiveMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newLiquidationIncentiveMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewLiquidationIncentive",
-            "type": "event",
-            "signature": "0xaeba5a6c40a8ac138134bff1aaa65debf25971188a58804bad717f82f0ec1316"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldMaxAssets",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newMaxAssets",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewMaxAssets",
-            "type": "event",
-            "signature": "0x7093cf1eb653f749c3ff531d6df7f92764536a7fa0d13530cd26e070780c32ea"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldPriceOracle",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newPriceOracle",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPriceOracle",
-            "type": "event",
-            "signature": "0xd52b2b9b7e9ee655fcb95d2e5b9e0c9f69e7ef2b8e9d2d0ea78402d576d22e22"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "error",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "info",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "detail",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Failure",
-            "type": "event",
-            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
         }
     ],
     "Unitroller": [
@@ -14996,6 +11105,322 @@
             "signature": "0x8d925ccd"
         }
     ],
+    "LegacyJumpRateModelV2": [
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "owner_",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseRatePerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "multiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "kink",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewInterestParams",
+            "type": "event",
+            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "baseRatePerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf14039de"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "blocksPerYear",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xa385fb96"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getBorrowRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x15f24053"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getSupplyRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb8168816"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isInterestRateModel",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x2191f92a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "jumpMultiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb9f9850a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "kink",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xfd2da339"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "multiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8726bb89"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8da5cb5b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                }
+            ],
+            "name": "updateJumpRateModel",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x2037f3e7"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "utilizationRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x6e71e2d8"
+        }
+    ],
     "USDT": [
         {
             "anonymous": false,
@@ -15404,7 +11829,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x26782247"
         },
         {
             "constant": false,
@@ -15423,7 +11849,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xb71d1a0c"
         },
         {
             "constant": true,
@@ -15437,7 +11864,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xbb82aa5e"
         },
         {
             "constant": false,
@@ -15451,7 +11879,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xc1e80334"
         },
         {
             "constant": true,
@@ -15465,7 +11894,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xdcfbc0c7"
         },
         {
             "constant": false,
@@ -15484,7 +11914,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe992a041"
         },
         {
             "constant": false,
@@ -15498,7 +11929,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe9c714f2"
         },
         {
             "constant": true,
@@ -15512,13 +11944,15 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xf851a440"
         },
         {
             "inputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "constructor"
+            "type": "constructor",
+            "signature": "constructor"
         },
         {
             "payable": true,
@@ -15540,7 +11974,8 @@
                 }
             ],
             "name": "NewPendingImplementation",
-            "type": "event"
+            "type": "event",
+            "signature": "0xe945ccee5d701fc83f9b8aa8ca94ea4219ec1fcbd4f4cab4f0ea57c5c3e1d815"
         },
         {
             "anonymous": false,
@@ -15557,7 +11992,8 @@
                 }
             ],
             "name": "NewImplementation",
-            "type": "event"
+            "type": "event",
+            "signature": "0xd604de94d45953f9138079ec1b82d533cb2160c906d1076d1f7ed54befbca97a"
         },
         {
             "anonymous": false,
@@ -15574,7 +12010,8 @@
                 }
             ],
             "name": "NewPendingAdmin",
-            "type": "event"
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
         },
         {
             "anonymous": false,
@@ -15591,7 +12028,8 @@
                 }
             ],
             "name": "NewAdmin",
-            "type": "event"
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
         },
         {
             "anonymous": false,
@@ -15613,13 +12051,15 @@
                 }
             ],
             "name": "Failure",
-            "type": "event"
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
         },
         {
             "inputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "constructor"
+            "type": "constructor",
+            "signature": "constructor"
         },
         {
             "anonymous": false,
@@ -15638,7 +12078,8 @@
                 }
             ],
             "name": "ActionPaused",
-            "type": "event"
+            "type": "event",
+            "signature": "0xef159d9a32b2472e32b098f954f3ce62d232939f1c207070b584df1814de2de0"
         },
         {
             "anonymous": false,
@@ -15663,26 +12104,8 @@
                 }
             ],
             "name": "ActionPaused",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "recipient",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "CompGranted",
-            "type": "event"
+            "type": "event",
+            "signature": "0x71aec636243f9709bb0007ae15e9afb8150ab01716d75fd7573be5cc096e03b0"
         },
         {
             "anonymous": false,
@@ -15701,26 +12124,8 @@
                 }
             ],
             "name": "CompSpeedUpdated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "contributor",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newSpeed",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ContributorCompSpeedUpdated",
-            "type": "event"
+            "type": "event",
+            "signature": "0x2ab93f65628379309f36cb125e90d7c902454a545c4f8b8cb0794af75c24b807"
         },
         {
             "anonymous": false,
@@ -15751,7 +12156,8 @@
                 }
             ],
             "name": "DistributedBorrowerComp",
-            "type": "event"
+            "type": "event",
+            "signature": "0x1fc3ecc087d8d2d15e23d0032af5a47059c3892d003d8e139fdcb6bb327c99a6"
         },
         {
             "anonymous": false,
@@ -15782,7 +12188,8 @@
                 }
             ],
             "name": "DistributedSupplierComp",
-            "type": "event"
+            "type": "event",
+            "signature": "0x2caecd17d02f56fa897705dcc740da2d237c373f70686f4e0d9bd3bf0400ea7a"
         },
         {
             "anonymous": false,
@@ -15807,7 +12214,28 @@
                 }
             ],
             "name": "Failure",
-            "type": "event"
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isComped",
+                    "type": "bool"
+                }
+            ],
+            "name": "MarketComped",
+            "type": "event",
+            "signature": "0x93c1f3e36ed71139f466a4ce8c9751790e2e33f5afb2df0dcfb3aeabe55d5aa2"
         },
         {
             "anonymous": false,
@@ -15826,7 +12254,8 @@
                 }
             ],
             "name": "MarketEntered",
-            "type": "event"
+            "type": "event",
+            "signature": "0x3ab23ab0d51cccc0c3085aec51f99228625aa1a922b3a8ca89a26b0f2027a1a5"
         },
         {
             "anonymous": false,
@@ -15845,7 +12274,8 @@
                 }
             ],
             "name": "MarketExited",
-            "type": "event"
+            "type": "event",
+            "signature": "0xe699a64c18b07ac5b7301aa273f36a2287239eb9501d81950672794afba29a0d"
         },
         {
             "anonymous": false,
@@ -15858,7 +12288,8 @@
                 }
             ],
             "name": "MarketListed",
-            "type": "event"
+            "type": "event",
+            "signature": "0xcf583bb0c569eb967f806b11601c4cb93c10310485c67add5f8362c2f212321f"
         },
         {
             "anonymous": false,
@@ -15877,7 +12308,8 @@
                 }
             ],
             "name": "NewBorrowCap",
-            "type": "event"
+            "type": "event",
+            "signature": "0x6f1951b2aad10f3fc81b86d91105b413a5b3f847a34bbc5ce1904201b14438f6"
         },
         {
             "anonymous": false,
@@ -15896,7 +12328,8 @@
                 }
             ],
             "name": "NewBorrowCapGuardian",
-            "type": "event"
+            "type": "event",
+            "signature": "0xeda98690e518e9a05f8ec6837663e188211b2da8f4906648b323f2c1d4434e29"
         },
         {
             "anonymous": false,
@@ -15915,7 +12348,8 @@
                 }
             ],
             "name": "NewCloseFactor",
-            "type": "event"
+            "type": "event",
+            "signature": "0x3b9670cf975d26958e754b57098eaa2ac914d8d2a31b83257997b9f346110fd9"
         },
         {
             "anonymous": false,
@@ -15940,7 +12374,28 @@
                 }
             ],
             "name": "NewCollateralFactor",
-            "type": "event"
+            "type": "event",
+            "signature": "0x70483e6592cd5182d45ac970e05bc62cdcc90e9d8ef2c2dbe686cf383bcd7fc5"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCompRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCompRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCompRate",
+            "type": "event",
+            "signature": "0xc227c9272633c3a307d9845bf2bc2509cefb20d655b5f3c1002d8e1e3f22c8b0"
         },
         {
             "anonymous": false,
@@ -15959,7 +12414,28 @@
                 }
             ],
             "name": "NewLiquidationIncentive",
-            "type": "event"
+            "type": "event",
+            "signature": "0xaeba5a6c40a8ac138134bff1aaa65debf25971188a58804bad717f82f0ec1316"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldMaxAssets",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newMaxAssets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewMaxAssets",
+            "type": "event",
+            "signature": "0x7093cf1eb653f749c3ff531d6df7f92764536a7fa0d13530cd26e070780c32ea"
         },
         {
             "anonymous": false,
@@ -15978,7 +12454,8 @@
                 }
             ],
             "name": "NewPauseGuardian",
-            "type": "event"
+            "type": "event",
+            "signature": "0x0613b6ee6a04f0d09f390e4d9318894b9f6ac7fd83897cd8d18896ba579c401e"
         },
         {
             "anonymous": false,
@@ -15997,7 +12474,24 @@
                 }
             ],
             "name": "NewPriceOracle",
-            "type": "event"
+            "type": "event",
+            "signature": "0xd52b2b9b7e9ee655fcb95d2e5b9e0c9f69e7ef2b8e9d2d0ea78402d576d22e22"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "_addCompMarkets",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xce485c5e"
         },
         {
             "constant": false,
@@ -16012,7 +12506,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x1d504dc6"
         },
         {
             "constant": true,
@@ -16027,27 +12522,24 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe6653f3d"
         },
         {
             "constant": false,
             "inputs": [
                 {
                     "internalType": "address",
-                    "name": "recipient",
+                    "name": "cToken",
                     "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
                 }
             ],
-            "name": "_grantComp",
+            "name": "_dropCompMarket",
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x3aa729b4"
         },
         {
             "constant": true,
@@ -16062,7 +12554,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x3c94786f"
         },
         {
             "constant": false,
@@ -16077,7 +12570,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x391957d7"
         },
         {
             "constant": false,
@@ -16103,7 +12597,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x18c882a5"
         },
         {
             "constant": false,
@@ -16124,7 +12619,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x317b0b77"
         },
         {
             "constant": false,
@@ -16150,47 +12646,24 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe4028eee"
         },
         {
             "constant": false,
             "inputs": [
                 {
-                    "internalType": "contract CToken",
-                    "name": "cToken",
-                    "type": "address"
-                },
-                {
                     "internalType": "uint256",
-                    "name": "compSpeed",
+                    "name": "compRate_",
                     "type": "uint256"
                 }
             ],
-            "name": "_setCompSpeed",
+            "name": "_setCompRate",
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "contributor",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "compSpeed",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setContributorCompSpeed",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6a491112"
         },
         {
             "constant": false,
@@ -16211,7 +12684,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x4fd42e17"
         },
         {
             "constant": false,
@@ -16231,7 +12705,30 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x607ef6c1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newMaxAssets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setMaxAssets",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd9226ced"
         },
         {
             "constant": false,
@@ -16257,7 +12754,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x3bcf7ec1"
         },
         {
             "constant": false,
@@ -16278,7 +12776,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x5f5af1aa"
         },
         {
             "constant": false,
@@ -16299,7 +12798,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x55ee1fe1"
         },
         {
             "constant": false,
@@ -16320,7 +12820,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x2d70db78"
         },
         {
             "constant": false,
@@ -16341,7 +12842,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x8ebf6364"
         },
         {
             "constant": false,
@@ -16362,7 +12864,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xa76b3fda"
         },
         {
             "constant": true,
@@ -16388,7 +12891,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xdce15449"
         },
         {
             "constant": true,
@@ -16403,7 +12907,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xf851a440"
         },
         {
             "constant": true,
@@ -16424,7 +12929,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x52d84d1e"
         },
         {
             "constant": false,
@@ -16455,7 +12961,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xda3d454c"
         },
         {
             "constant": true,
@@ -16470,7 +12977,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x21af4569"
         },
         {
             "constant": true,
@@ -16491,7 +12999,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x4a584432"
         },
         {
             "constant": true,
@@ -16512,7 +13021,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6d154ea5"
         },
         {
             "constant": false,
@@ -16537,7 +13047,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x5c778605"
         },
         {
             "constant": true,
@@ -16563,7 +13074,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x929fe9a1"
         },
         {
             "constant": false,
@@ -16583,7 +13095,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x1c3db2e0"
         },
         {
             "constant": false,
@@ -16613,7 +13126,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6810dfa6"
         },
         {
             "constant": false,
@@ -16628,7 +13142,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe9af0292"
         },
         {
             "constant": true,
@@ -16643,7 +13158,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xe8755446"
         },
         {
             "constant": true,
@@ -16664,7 +13180,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xcc7ebdc4"
         },
         {
             "constant": true,
@@ -16690,7 +13207,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x8c57804e"
         },
         {
             "constant": true,
@@ -16716,18 +13234,13 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xca0af043"
         },
         {
             "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "compContributorSpeeds",
+            "inputs": [],
+            "name": "compClaimThreshold",
             "outputs": [
                 {
                     "internalType": "uint256",
@@ -16737,7 +13250,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x747026c9"
         },
         {
             "constant": true,
@@ -16752,7 +13266,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xa7f0e231"
         },
         {
             "constant": true,
@@ -16767,7 +13282,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xaa900754"
         },
         {
             "constant": true,
@@ -16788,7 +13304,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x1d7b33d7"
         },
         {
             "constant": true,
@@ -16814,7 +13331,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xb21be7fd"
         },
         {
             "constant": true,
@@ -16840,7 +13358,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6b79c38d"
         },
         {
             "constant": true,
@@ -16855,7 +13374,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xbb82aa5e"
         },
         {
             "constant": false,
@@ -16876,7 +13396,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xc2998238"
         },
         {
             "constant": false,
@@ -16897,7 +13418,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xede4edd0"
         },
         {
             "constant": true,
@@ -16928,7 +13450,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x5ec88c79"
         },
         {
             "constant": true,
@@ -16943,7 +13466,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xb0772d0b"
         },
         {
             "constant": true,
@@ -16964,7 +13488,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xabfceffc"
         },
         {
             "constant": true,
@@ -16979,7 +13504,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x42cbb15c"
         },
         {
             "constant": true,
@@ -16994,7 +13520,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x9d1b5a0a"
         },
         {
             "constant": true,
@@ -17040,7 +13567,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x4e79238f"
         },
         {
             "constant": true,
@@ -17055,28 +13583,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "lastContributorBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x007e3dd2"
         },
         {
             "constant": false,
@@ -17117,7 +13625,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x5fc7e71e"
         },
         {
             "constant": false,
@@ -17157,7 +13666,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x47ef3b3b"
         },
         {
             "constant": true,
@@ -17193,7 +13703,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xc488847b"
         },
         {
             "constant": true,
@@ -17208,7 +13719,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x4ada90af"
         },
         {
             "constant": true,
@@ -17239,7 +13751,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x8e8f294b"
         },
         {
             "constant": true,
@@ -17254,7 +13767,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x94b2294b"
         },
         {
             "constant": false,
@@ -17285,7 +13799,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x4ef4c3e1"
         },
         {
             "constant": true,
@@ -17306,7 +13821,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x731f0c2b"
         },
         {
             "constant": false,
@@ -17336,7 +13852,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x41c728b9"
         },
         {
             "constant": true,
@@ -17351,7 +13868,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x7dc0d1d0"
         },
         {
             "constant": true,
@@ -17366,7 +13884,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x24a3d622"
         },
         {
             "constant": true,
@@ -17381,7 +13900,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x26782247"
         },
         {
             "constant": true,
@@ -17396,7 +13916,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xdcfbc0c7"
         },
         {
             "constant": false,
@@ -17427,7 +13948,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xeabe7d91"
         },
         {
             "constant": false,
@@ -17457,7 +13979,18 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x51dff989"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "refreshCompSpeeds",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4d8e5037"
         },
         {
             "constant": false,
@@ -17493,7 +14026,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x24008a62"
         },
         {
             "constant": false,
@@ -17528,7 +14062,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x1ededc91"
         },
         {
             "constant": false,
@@ -17569,7 +14104,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xd02f7351"
         },
         {
             "constant": true,
@@ -17584,7 +14120,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xac0b0bb7"
         },
         {
             "constant": false,
@@ -17619,7 +14156,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6d35bf91"
         },
         {
             "constant": false,
@@ -17655,7 +14193,8 @@
             ],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xbdcdc258"
         },
         {
             "constant": true,
@@ -17670,7 +14209,8 @@
             ],
             "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x87f76303"
         },
         {
             "constant": false,
@@ -17700,22 +14240,8 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "contributor",
-                    "type": "address"
-                }
-            ],
-            "name": "updateContributorRewards",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0x6a56947e"
         }
     ],
     "Comp": [
@@ -21037,6 +17563,165 @@
             "name": "Approval",
             "type": "event",
             "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        }
+    ],
+    "PriceData": [
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "priorTimestamp",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "messageTimestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "blockTimestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NotWritten",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "source",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "key",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "timestamp",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "value",
+                    "type": "uint64"
+                }
+            ],
+            "name": "Write",
+            "type": "event"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "source",
+                    "type": "address"
+                },
+                {
+                    "internalType": "string",
+                    "name": "key",
+                    "type": "string"
+                }
+            ],
+            "name": "get",
+            "outputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "source",
+                    "type": "address"
+                },
+                {
+                    "internalType": "string",
+                    "name": "key",
+                    "type": "string"
+                }
+            ],
+            "name": "getPrice",
+            "outputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "message",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "put",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "message",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "source",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
         }
     ],
     "StableCoinInterestRateModel": [
@@ -27122,6 +23807,317 @@
             "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
         }
     ],
+    "JumpRateModelV2": [
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "owner_",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseRatePerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "multiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "kink",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewInterestParams",
+            "type": "event",
+            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "baseRatePerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf14039de"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "blocksPerYear",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xa385fb96"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getBorrowRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x15f24053"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getSupplyRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb8168816"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isInterestRateModel",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x2191f92a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "jumpMultiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb9f9850a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "kink",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xfd2da339"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "multiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8726bb89"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8da5cb5b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                }
+            ],
+            "name": "updateJumpRateModel",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x2037f3e7"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "utilizationRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x6e71e2d8"
+        }
+    ],
     "DSR_Kink_9000bps_Jump_12000bps_AssumedRF_20000bps": [
         {
             "inputs": [
@@ -31440,3411 +28436,6 @@
             "signature": "constructor"
         }
     ],
-    "cREP": [
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x06fdde03"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x095ea7b3"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x0e752702"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "reserveFactorMantissa",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x173b9904"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceCurrent",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x17bfdfbc"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x18160ddd"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "exchangeRateStored",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x182df0f5"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x23b872dd"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrowBehalf",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x2608f818"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x26782247"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x313ce567"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOfUnderlying",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x3af9e669"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "getCash",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x3b1d21a2"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "_setComptroller",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x4576b5db"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalBorrows",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x47bd3718"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "comptroller",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x5fe3b567"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_reduceReserves",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x601a0bf1"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "initialExchangeRateMantissa",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x675d972c"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "accrualBlockNumber",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x6c540baf"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "underlying",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x6f307dc3"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x70a08231"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "totalBorrowsCurrent",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x73acee98"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeemUnderlying",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x852a12e3"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalReserves",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8f840ddd"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x95d89b41"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalanceStored",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x95dd9193"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "mintAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xa0712d68"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "accrueInterest",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xa6afed95"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xa9059cbb"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowIndex",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xaa5af0fd"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "supplyRatePerBlock",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xae9d70b0"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "seize",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xb2a02ff1"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "_setPendingAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xb71d1a0c"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "exchangeRateCurrent",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xbd6d894d"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountSnapshot",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xc37f68e2"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xc5ebeaec"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "redeem",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xdb006a75"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xdd62ed3e"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "_acceptAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xe9c714f2"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "_setInterestRateModel",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xf2b3abbd"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "interestRateModel",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf3fdb15a"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                }
-            ],
-            "name": "liquidateBorrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xf5e3c462"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf851a440"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "borrowRatePerBlock",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf8f9da28"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setReserveFactor",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0xfca7820b"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isCToken",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xfe9c44ae"
-        },
-        {
-            "inputs": [
-                {
-                    "name": "underlying_",
-                    "type": "address"
-                },
-                {
-                    "name": "comptroller_",
-                    "type": "address"
-                },
-                {
-                    "name": "interestRateModel_",
-                    "type": "address"
-                },
-                {
-                    "name": "initialExchangeRateMantissa_",
-                    "type": "uint256"
-                },
-                {
-                    "name": "name_",
-                    "type": "string"
-                },
-                {
-                    "name": "symbol_",
-                    "type": "string"
-                },
-                {
-                    "name": "decimals_",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "interestAccumulated",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowIndex",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "AccrueInterest",
-            "type": "event",
-            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "minter",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "mintAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "mintTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Mint",
-            "type": "event",
-            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "redeemer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "redeemAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "redeemTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Redeem",
-            "type": "event",
-            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Borrow",
-            "type": "event",
-            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "payer",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "accountBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                }
-            ],
-            "name": "RepayBorrow",
-            "type": "event",
-            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrower",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "repayAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "cTokenCollateral",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "seizeTokens",
-                    "type": "uint256"
-                }
-            ],
-            "name": "LiquidateBorrow",
-            "type": "event",
-            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldPendingAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPendingAdmin",
-            "type": "event",
-            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewAdmin",
-            "type": "event",
-            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldComptroller",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newComptroller",
-                    "type": "address"
-                }
-            ],
-            "name": "NewComptroller",
-            "type": "event",
-            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldInterestRateModel",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newInterestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "NewMarketInterestRateModel",
-            "type": "event",
-            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldReserveFactorMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newReserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewReserveFactor",
-            "type": "event",
-            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "admin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "reduceAmount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newTotalReserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "ReservesReduced",
-            "type": "event",
-            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "error",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "info",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "detail",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Failure",
-            "type": "event",
-            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "from",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event",
-            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event",
-            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
-        }
-    ],
-    "Base200bps_Slope2000bps_Jump8000bps_Kink90": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event",
-            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf14039de"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xa385fb96"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x15f24053"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb8168816"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x2191f92a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jumpMultiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb9f9850a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xfd2da339"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8726bb89"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function",
-            "signature": "0x6e71e2d8"
-        }
-    ],
-    "Base200bps_Slope222bps_Kink90_Jump40": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jump_",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jump",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event",
-            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf14039de"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xa385fb96"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x15f24053"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb8168816"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x2191f92a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jump",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8f6c696b"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xfd2da339"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8726bb89"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function",
-            "signature": "0x6e71e2d8"
-        }
-    ],
-    "SAI": [
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "stop",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "owner_",
-                    "type": "address"
-                }
-            ],
-            "name": "setOwner",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "burn",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "name_",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "setName",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "stopped",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "authority_",
-                    "type": "address"
-                }
-            ],
-            "name": "setAuthority",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "burn",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "mint",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "push",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "move",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "start",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "authority",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "guy",
-                    "type": "address"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "guy",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "pull",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "name": "symbol_",
-                    "type": "bytes32"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Mint",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Burn",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "authority",
-                    "type": "address"
-                }
-            ],
-            "name": "LogSetAuthority",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "LogSetOwner",
-            "type": "event"
-        },
-        {
-            "anonymous": true,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "sig",
-                    "type": "bytes4"
-                },
-                {
-                    "indexed": true,
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "name": "foo",
-                    "type": "bytes32"
-                },
-                {
-                    "indexed": true,
-                    "name": "bar",
-                    "type": "bytes32"
-                },
-                {
-                    "indexed": false,
-                    "name": "wad",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "fax",
-                    "type": "bytes"
-                }
-            ],
-            "name": "LogNote",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "name": "guy",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "name": "src",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "name": "dst",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "wad",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event"
-        }
-    ],
-    "MoneyMarket": [
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "pendingAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "paused",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "oracle",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "liquidationDiscount",
-            "outputs": [
-                {
-                    "name": "mantissa",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "markets",
-            "outputs": [
-                {
-                    "name": "isSupported",
-                    "type": "bool"
-                },
-                {
-                    "name": "blockNumber",
-                    "type": "uint256"
-                },
-                {
-                    "name": "interestRateModel",
-                    "type": "address"
-                },
-                {
-                    "name": "totalSupply",
-                    "type": "uint256"
-                },
-                {
-                    "name": "supplyRateMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "name": "supplyIndex",
-                    "type": "uint256"
-                },
-                {
-                    "name": "totalBorrows",
-                    "type": "uint256"
-                },
-                {
-                    "name": "borrowRateMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "name": "borrowIndex",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "collateralRatio",
-            "outputs": [
-                {
-                    "name": "mantissa",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                },
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "supplyBalances",
-            "outputs": [
-                {
-                    "name": "principal",
-                    "type": "uint256"
-                },
-                {
-                    "name": "interestIndex",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "originationFee",
-            "outputs": [
-                {
-                    "name": "mantissa",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "name": "collateralMarkets",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "admin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "",
-                    "type": "address"
-                },
-                {
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "name": "borrowBalances",
-            "outputs": [
-                {
-                    "name": "principal",
-                    "type": "uint256"
-                },
-                {
-                    "name": "interestIndex",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "payable": true,
-            "stateMutability": "payable",
-            "type": "fallback"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "startingBalance",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newBalance",
-                    "type": "uint256"
-                }
-            ],
-            "name": "SupplyReceived",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "startingBalance",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newBalance",
-                    "type": "uint256"
-                }
-            ],
-            "name": "SupplyWithdrawn",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "startingBalance",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowAmountWithFee",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newBalance",
-                    "type": "uint256"
-                }
-            ],
-            "name": "BorrowTaken",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "startingBalance",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newBalance",
-                    "type": "uint256"
-                }
-            ],
-            "name": "BorrowRepaid",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "targetAccount",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "assetBorrow",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowBalanceBefore",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowBalanceAccumulated",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "amountRepaid",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "borrowBalanceAfter",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "liquidator",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "assetCollateral",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "collateralBalanceBefore",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "collateralBalanceAccumulated",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "amountSeized",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "collateralBalanceAfter",
-                    "type": "uint256"
-                }
-            ],
-            "name": "BorrowLiquidated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldPendingAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewPendingAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldAdmin",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "NewAdmin",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldOracle",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "newOracle",
-                    "type": "address"
-                }
-            ],
-            "name": "NewOracle",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "interestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "SupportedMarket",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldCollateralRatioMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newCollateralRatioMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "oldLiquidationDiscountMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newLiquidationDiscountMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewRiskParameters",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "oldOriginationFeeMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "newOriginationFeeMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewOriginationFee",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "interestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "SetMarketInterestRateModel",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "name": "equityAvailableBefore",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "amount",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "EquityWithdrawn",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "asset",
-                    "type": "address"
-                }
-            ],
-            "name": "SuspendedMarket",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "newState",
-                    "type": "bool"
-                }
-            ],
-            "name": "SetPaused",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "name": "error",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "info",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "name": "detail",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Failure",
-            "type": "event"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "getCollateralMarketsLength",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                }
-            ],
-            "name": "assetPrices",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newPendingAdmin",
-                    "type": "address"
-                }
-            ],
-            "name": "_setPendingAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [],
-            "name": "_acceptAdmin",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "newOracle",
-                    "type": "address"
-                }
-            ],
-            "name": "_setOracle",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "requestedState",
-                    "type": "bool"
-                }
-            ],
-            "name": "_setPaused",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "getAccountLiquidity",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "int256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "name": "asset",
-                    "type": "address"
-                }
-            ],
-            "name": "getSupplyBalance",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "account",
-                    "type": "address"
-                },
-                {
-                    "name": "asset",
-                    "type": "address"
-                }
-            ],
-            "name": "getBorrowBalance",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "interestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "_supportMarket",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                }
-            ],
-            "name": "_suspendMarket",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "collateralRatioMantissa",
-                    "type": "uint256"
-                },
-                {
-                    "name": "liquidationDiscountMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setRiskParameters",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "originationFeeMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_setOriginationFee",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "interestRateModel",
-                    "type": "address"
-                }
-            ],
-            "name": "_setMarketInterestRateModel",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "_withdrawEquity",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "supply",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "requestedAmount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "withdraw",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "name": "userAddress",
-                    "type": "address"
-                }
-            ],
-            "name": "calculateAccountValues",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "repayBorrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "targetAccount",
-                    "type": "address"
-                },
-                {
-                    "name": "assetBorrow",
-                    "type": "address"
-                },
-                {
-                    "name": "assetCollateral",
-                    "type": "address"
-                },
-                {
-                    "name": "requestedAmountClose",
-                    "type": "uint256"
-                }
-            ],
-            "name": "liquidateBorrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "name": "asset",
-                    "type": "address"
-                },
-                {
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "borrow",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        }
-    ],
     "StdComptrollerG4": [
         {
             "inputs": [],
@@ -39112,6 +32703,5702 @@
             "signature": "0x6a56947e"
         }
     ],
+    "cREP": [
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x06fdde03"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x095ea7b3"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x0e752702"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "reserveFactorMantissa",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x173b9904"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowBalanceCurrent",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x17bfdfbc"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x18160ddd"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "exchangeRateStored",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x182df0f5"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x23b872dd"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrowBehalf",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x2608f818"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x26782247"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x313ce567"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOfUnderlying",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x3af9e669"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getCash",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3b1d21a2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "_setComptroller",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4576b5db"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "totalBorrows",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x47bd3718"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "comptroller",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x5fe3b567"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_reduceReserves",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x601a0bf1"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "initialExchangeRateMantissa",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x675d972c"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "accrualBlockNumber",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x6c540baf"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "underlying",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x6f307dc3"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x70a08231"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "totalBorrowsCurrent",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x73acee98"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeemUnderlying",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x852a12e3"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "totalReserves",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8f840ddd"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x95d89b41"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowBalanceStored",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x95dd9193"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "mintAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xa0712d68"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "accrueInterest",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xa6afed95"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xa9059cbb"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "borrowIndex",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xaa5af0fd"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "supplyRatePerBlock",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xae9d70b0"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "seize",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xb2a02ff1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPendingAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xb71d1a0c"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "exchangeRateCurrent",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xbd6d894d"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAccountSnapshot",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xc37f68e2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xc5ebeaec"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeem",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xdb006a75"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdd62ed3e"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "_acceptAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe9c714f2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "_setInterestRateModel",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xf2b3abbd"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "interestRateModel",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf3fdb15a"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                }
+            ],
+            "name": "liquidateBorrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xf5e3c462"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "admin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf851a440"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "borrowRatePerBlock",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf8f9da28"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setReserveFactor",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xfca7820b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isCToken",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xfe9c44ae"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "underlying_",
+                    "type": "address"
+                },
+                {
+                    "name": "comptroller_",
+                    "type": "address"
+                },
+                {
+                    "name": "interestRateModel_",
+                    "type": "address"
+                },
+                {
+                    "name": "initialExchangeRateMantissa_",
+                    "type": "uint256"
+                },
+                {
+                    "name": "name_",
+                    "type": "string"
+                },
+                {
+                    "name": "symbol_",
+                    "type": "string"
+                },
+                {
+                    "name": "decimals_",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        }
+    ],
+    "Base200bps_Slope2000bps_Jump8000bps_Kink90": [
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseRatePerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "multiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "jumpMultiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "kink",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewInterestParams",
+            "type": "event",
+            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "baseRatePerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf14039de"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "blocksPerYear",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xa385fb96"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getBorrowRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x15f24053"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getSupplyRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb8168816"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isInterestRateModel",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x2191f92a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "jumpMultiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb9f9850a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "kink",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xfd2da339"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "multiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8726bb89"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "utilizationRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x6e71e2d8"
+        }
+    ],
+    "StdComptrollerG6": [
+        {
+            "inputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionPaused",
+            "type": "event",
+            "signature": "0xef159d9a32b2472e32b098f954f3ce62d232939f1c207070b584df1814de2de0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "ActionPaused",
+            "type": "event",
+            "signature": "0x71aec636243f9709bb0007ae15e9afb8150ab01716d75fd7573be5cc096e03b0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CompGranted",
+            "type": "event",
+            "signature": "0x98b2f82a3a07f223a0be64b3d0f47711c64dccd1feafb94aa28156b38cd9695c"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CompSpeedUpdated",
+            "type": "event",
+            "signature": "0x2ab93f65628379309f36cb125e90d7c902454a545c4f8b8cb0794af75c24b807"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "contributor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ContributorCompSpeedUpdated",
+            "type": "event",
+            "signature": "0x386537fa92edc3319af95f1f904dcf1900021e4f3f4e08169a577a09076e66b3"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "compDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "compBorrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedBorrowerComp",
+            "type": "event",
+            "signature": "0x1fc3ecc087d8d2d15e23d0032af5a47059c3892d003d8e139fdcb6bb327c99a6"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "supplier",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "compDelta",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "compSupplyIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DistributedSupplierComp",
+            "type": "event",
+            "signature": "0x2caecd17d02f56fa897705dcc740da2d237c373f70686f4e0d9bd3bf0400ea7a"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isComped",
+                    "type": "bool"
+                }
+            ],
+            "name": "MarketComped",
+            "type": "event",
+            "signature": "0x93c1f3e36ed71139f466a4ce8c9751790e2e33f5afb2df0dcfb3aeabe55d5aa2"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketEntered",
+            "type": "event",
+            "signature": "0x3ab23ab0d51cccc0c3085aec51f99228625aa1a922b3a8ca89a26b0f2027a1a5"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketExited",
+            "type": "event",
+            "signature": "0xe699a64c18b07ac5b7301aa273f36a2287239eb9501d81950672794afba29a0d"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "MarketListed",
+            "type": "event",
+            "signature": "0xcf583bb0c569eb967f806b11601c4cb93c10310485c67add5f8362c2f212321f"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewBorrowCap",
+            "type": "event",
+            "signature": "0x6f1951b2aad10f3fc81b86d91105b413a5b3f847a34bbc5ce1904201b14438f6"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldBorrowCapGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newBorrowCapGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewBorrowCapGuardian",
+            "type": "event",
+            "signature": "0xeda98690e518e9a05f8ec6837663e188211b2da8f4906648b323f2c1d4434e29"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCloseFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCloseFactor",
+            "type": "event",
+            "signature": "0x3b9670cf975d26958e754b57098eaa2ac914d8d2a31b83257997b9f346110fd9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCollateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCollateralFactor",
+            "type": "event",
+            "signature": "0x70483e6592cd5182d45ac970e05bc62cdcc90e9d8ef2c2dbe686cf383bcd7fc5"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldCompRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCompRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCompRate",
+            "type": "event",
+            "signature": "0xc227c9272633c3a307d9845bf2bc2509cefb20d655b5f3c1002d8e1e3f22c8b0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewLiquidationIncentive",
+            "type": "event",
+            "signature": "0xaeba5a6c40a8ac138134bff1aaa65debf25971188a58804bad717f82f0ec1316"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPauseGuardian",
+            "type": "event",
+            "signature": "0x0613b6ee6a04f0d09f390e4d9318894b9f6ac7fd83897cd8d18896ba579c401e"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "oldPriceOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract PriceOracle",
+                    "name": "newPriceOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event",
+            "signature": "0xd52b2b9b7e9ee655fcb95d2e5b9e0c9f69e7ef2b8e9d2d0ea78402d576d22e22"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "_addCompMarkets",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xce485c5e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract Unitroller",
+                    "name": "unitroller",
+                    "type": "address"
+                }
+            ],
+            "name": "_become",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1d504dc6"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "_borrowGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xe6653f3d"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "_dropCompMarket",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x3aa729b4"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_grantComp",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x27efe3cb"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "_mintGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3c94786f"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newBorrowCapGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "_setBorrowCapGuardian",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x391957d7"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "state",
+                    "type": "bool"
+                }
+            ],
+            "name": "_setBorrowPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x18c882a5"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newCloseFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setCloseFactor",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x317b0b77"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "newCollateralFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setCollateralFactor",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe4028eee"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "compRate_",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setCompRate",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6a491112"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "contributor",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "compSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setContributorCompSpeed",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x598ee1cb"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newLiquidationIncentiveMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setLiquidationIncentive",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4fd42e17"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "newBorrowCaps",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "_setMarketBorrowCaps",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x607ef6c1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "state",
+                    "type": "bool"
+                }
+            ],
+            "name": "_setMintPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x3bcf7ec1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPauseGuardian",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x5f5af1aa"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract PriceOracle",
+                    "name": "newOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPriceOracle",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x55ee1fe1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "bool",
+                    "name": "state",
+                    "type": "bool"
+                }
+            ],
+            "name": "_setSeizePaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x2d70db78"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "bool",
+                    "name": "state",
+                    "type": "bool"
+                }
+            ],
+            "name": "_setTransferPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x8ebf6364"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "_supportMarket",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xa76b3fda"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "accountAssets",
+            "outputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdce15449"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "admin",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf851a440"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "allMarkets",
+            "outputs": [
+                {
+                    "internalType": "contract CToken",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x52d84d1e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrowAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xda3d454c"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "borrowCapGuardian",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x21af4569"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowCaps",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x4a584432"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x6d154ea5"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x5c778605"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract CToken",
+                    "name": "cToken",
+                    "type": "address"
+                }
+            ],
+            "name": "checkMembership",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x929fe9a1"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "holder",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "claimComp",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1c3db2e0"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "holders",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "borrowers",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "suppliers",
+                    "type": "bool"
+                }
+            ],
+            "name": "claimComp",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6810dfa6"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "holder",
+                    "type": "address"
+                }
+            ],
+            "name": "claimComp",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe9af0292"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "closeFactorMantissa",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xe8755446"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compAccrued",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xcc7ebdc4"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compBorrowState",
+            "outputs": [
+                {
+                    "internalType": "uint224",
+                    "name": "index",
+                    "type": "uint224"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "block",
+                    "type": "uint32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8c57804e"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compBorrowerIndex",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xca0af043"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "compClaimThreshold",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x747026c9"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compContributorSpeeds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x986ab838"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "compInitialIndex",
+            "outputs": [
+                {
+                    "internalType": "uint224",
+                    "name": "",
+                    "type": "uint224"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xa7f0e231"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "compRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xaa900754"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compSpeeds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x1d7b33d7"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compSupplierIndex",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb21be7fd"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "compSupplyState",
+            "outputs": [
+                {
+                    "internalType": "uint224",
+                    "name": "index",
+                    "type": "uint224"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "block",
+                    "type": "uint32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x6b79c38d"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "comptrollerImplementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xbb82aa5e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "cTokens",
+                    "type": "address[]"
+                }
+            ],
+            "name": "enterMarkets",
+            "outputs": [
+                {
+                    "internalType": "uint256[]",
+                    "name": "",
+                    "type": "uint256[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xc2998238"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "exitMarket",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xede4edd0"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAccountLiquidity",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x5ec88c79"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getAllMarkets",
+            "outputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb0772d0b"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAssetsIn",
+            "outputs": [
+                {
+                    "internalType": "contract CToken[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xabfceffc"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getBlockNumber",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x42cbb15c"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getCompAddress",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x9d1b5a0a"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenModify",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getHypotheticalAccountLiquidity",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x4e79238f"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isComptroller",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x007e3dd2"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "lastContributorBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xbea6b8b8"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateBorrowAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x5fc7e71e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "actualRepayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateBorrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x47ef3b3b"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "actualRepayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateCalculateSeizeTokens",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xc488847b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "liquidationIncentiveMantissa",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x4ada90af"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "markets",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "isListed",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "collateralFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "isComped",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8e8f294b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "maxAssets",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x94b2294b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "mintAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mintAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4ef4c3e1"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "mintGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x731f0c2b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "actualMintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mintVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x41c728b9"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "oracle",
+            "outputs": [
+                {
+                    "internalType": "contract PriceOracle",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x7dc0d1d0"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pauseGuardian",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x24a3d622"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x26782247"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingComptrollerImplementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdcfbc0c7"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeemAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xeabe7d91"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "redeemVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x51dff989"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "refreshCompSpeeds",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x4d8e5037"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "repayAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrowAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x24008a62"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "actualRepayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrowerIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrowVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1ededc91"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "seizeAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd02f7351"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "seizeGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xac0b0bb7"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "cTokenBorrowed",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "seizeVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6d35bf91"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "transferTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferAllowed",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xbdcdc258"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "transferGuardianPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x87f76303"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "cToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "transferTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferVerify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x6a56947e"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "contributor",
+                    "type": "address"
+                }
+            ],
+            "name": "updateContributorRewards",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x741b2525"
+        }
+    ],
+    "Base200bps_Slope222bps_Kink90_Jump40": [
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "baseRatePerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "multiplierPerYear",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "kink_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "jump_",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseRatePerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "multiplierPerBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "kink",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "jump",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewInterestParams",
+            "type": "event",
+            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "baseRatePerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xf14039de"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "blocksPerYear",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xa385fb96"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getBorrowRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x15f24053"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getSupplyRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb8168816"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isInterestRateModel",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x2191f92a"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "jump",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8f6c696b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "kink",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xfd2da339"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "multiplierPerBlock",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x8726bb89"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "cash",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrows",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "reserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "utilizationRate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x6e71e2d8"
+        }
+    ],
+    "SAI": [
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "stop",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "owner_",
+                    "type": "address"
+                }
+            ],
+            "name": "setOwner",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "name_",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "setName",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "stopped",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "authority_",
+                    "type": "address"
+                }
+            ],
+            "name": "setAuthority",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "push",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "move",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "start",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "authority",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "guy",
+                    "type": "address"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "guy",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "pull",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "symbol_",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        }
+    ],
+    "MoneyMarket": [
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "paused",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "oracle",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "liquidationDiscount",
+            "outputs": [
+                {
+                    "name": "mantissa",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "markets",
+            "outputs": [
+                {
+                    "name": "isSupported",
+                    "type": "bool"
+                },
+                {
+                    "name": "blockNumber",
+                    "type": "uint256"
+                },
+                {
+                    "name": "interestRateModel",
+                    "type": "address"
+                },
+                {
+                    "name": "totalSupply",
+                    "type": "uint256"
+                },
+                {
+                    "name": "supplyRateMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "name": "supplyIndex",
+                    "type": "uint256"
+                },
+                {
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "name": "borrowRateMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "collateralRatio",
+            "outputs": [
+                {
+                    "name": "mantissa",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "supplyBalances",
+            "outputs": [
+                {
+                    "name": "principal",
+                    "type": "uint256"
+                },
+                {
+                    "name": "interestIndex",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "originationFee",
+            "outputs": [
+                {
+                    "name": "mantissa",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "collateralMarkets",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "admin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowBalances",
+            "outputs": [
+                {
+                    "name": "principal",
+                    "type": "uint256"
+                },
+                {
+                    "name": "interestIndex",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "payable": true,
+            "stateMutability": "payable",
+            "type": "fallback"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "startingBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyReceived",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "startingBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyWithdrawn",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "startingBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmountWithFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowTaken",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "startingBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowRepaid",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "targetAccount",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "assetBorrow",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowBalanceBefore",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowBalanceAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "amountRepaid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowBalanceAfter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "assetCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "collateralBalanceBefore",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "collateralBalanceAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "amountSeized",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "collateralBalanceAfter",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowLiquidated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldOracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewOracle",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "interestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "SupportedMarket",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldCollateralRatioMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCollateralRatioMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "oldLiquidationDiscountMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newLiquidationDiscountMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewRiskParameters",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldOriginationFeeMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newOriginationFeeMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewOriginationFee",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "interestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "SetMarketInterestRateModel",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "equityAvailableBefore",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "EquityWithdrawn",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "SuspendedMarket",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SetPaused",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getCollateralMarketsLength",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "assetPrices",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPendingAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "_acceptAdmin",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "newOracle",
+                    "type": "address"
+                }
+            ],
+            "name": "_setOracle",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "requestedState",
+                    "type": "bool"
+                }
+            ],
+            "name": "_setPaused",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getAccountLiquidity",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "int256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "getSupplyBalance",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "getBorrowBalance",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "interestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "_supportMarket",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "_suspendMarket",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "collateralRatioMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "name": "liquidationDiscountMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setRiskParameters",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "originationFeeMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setOriginationFee",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "interestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "_setMarketInterestRateModel",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_withdrawEquity",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "supply",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "requestedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdraw",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "userAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "calculateAccountValues",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "repayBorrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "targetAccount",
+                    "type": "address"
+                },
+                {
+                    "name": "assetBorrow",
+                    "type": "address"
+                },
+                {
+                    "name": "assetCollateral",
+                    "type": "address"
+                },
+                {
+                    "name": "requestedAmountClose",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateBorrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrow",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ],
     "cZRX": [
         {
             "constant": true,
@@ -42152,1600 +41439,14 @@
             "signature": "0x6e71e2d8"
         }
     ],
-    "PriceData": [
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint64",
-                    "name": "priorTimestamp",
-                    "type": "uint64"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "messageTimestamp",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "blockTimestamp",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NotWritten",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "source",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "key",
-                    "type": "string"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint64",
-                    "name": "timestamp",
-                    "type": "uint64"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint64",
-                    "name": "value",
-                    "type": "uint64"
-                }
-            ],
-            "name": "Write",
-            "type": "event"
-        },
+    "GovernorBravoDelegator": [
         {
             "inputs": [
                 {
                     "internalType": "address",
-                    "name": "source",
+                    "name": "timelock_",
                     "type": "address"
                 },
-                {
-                    "internalType": "string",
-                    "name": "key",
-                    "type": "string"
-                }
-            ],
-            "name": "get",
-            "outputs": [
-                {
-                    "internalType": "uint64",
-                    "name": "",
-                    "type": "uint64"
-                },
-                {
-                    "internalType": "uint64",
-                    "name": "",
-                    "type": "uint64"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "source",
-                    "type": "address"
-                },
-                {
-                    "internalType": "string",
-                    "name": "key",
-                    "type": "string"
-                }
-            ],
-            "name": "getPrice",
-            "outputs": [
-                {
-                    "internalType": "uint64",
-                    "name": "",
-                    "type": "uint64"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "message",
-                    "type": "bytes"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
-                }
-            ],
-            "name": "put",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "message",
-                    "type": "bytes"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
-                }
-            ],
-            "name": "source",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "pure",
-            "type": "function"
-        }
-    ],
-    "PriceFeed": [
-        {
-            "inputs": [
-                {
-                    "internalType": "contract OpenOraclePriceData",
-                    "name": "priceData_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "reporter_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "anchorToleranceMantissa_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "anchorPeriod_",
-                    "type": "uint256"
-                },
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig[]",
-                    "name": "configs",
-                    "type": "tuple[]"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "symbol",
-                    "type": "string"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "anchorPrice",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldTimestamp",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTimestamp",
-                    "type": "uint256"
-                }
-            ],
-            "name": "AnchorPriceUpdated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "symbol",
-                    "type": "string"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "reporter",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "anchor",
-                    "type": "uint256"
-                }
-            ],
-            "name": "PriceGuarded",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "string",
-                    "name": "symbol",
-                    "type": "string"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "price",
-                    "type": "uint256"
-                }
-            ],
-            "name": "PriceUpdated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "reporter",
-                    "type": "address"
-                }
-            ],
-            "name": "ReporterInvalidated",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "bytes32",
-                    "name": "symbolHash",
-                    "type": "bytes32"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldTimestamp",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newTimestamp",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "oldPrice",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "newPrice",
-                    "type": "uint256"
-                }
-            ],
-            "name": "UniswapWindowUpdated",
-            "type": "event"
-        },
-        {
-            "inputs": [],
-            "name": "anchorPeriod",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "ethBaseUnit",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "expScale",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "i",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getTokenConfig",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "getTokenConfigByCToken",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "string",
-                    "name": "symbol",
-                    "type": "string"
-                }
-            ],
-            "name": "getTokenConfigBySymbol",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "symbolHash",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "getTokenConfigBySymbolHash",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "underlying",
-                    "type": "address"
-                }
-            ],
-            "name": "getTokenConfigByUnderlying",
-            "outputs": [
-                {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "cToken",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "underlying",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bytes32",
-                            "name": "symbolHash",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "baseUnit",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "enum UniswapConfig.PriceSource",
-                            "name": "priceSource",
-                            "type": "uint8"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "fixedPrice",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "uniswapMarket",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "bool",
-                            "name": "isUniswapReversed",
-                            "type": "bool"
-                        }
-                    ],
-                    "internalType": "struct UniswapConfig.TokenConfig",
-                    "name": "",
-                    "type": "tuple"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "cToken",
-                    "type": "address"
-                }
-            ],
-            "name": "getUnderlyingPrice",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "message",
-                    "type": "bytes"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
-                }
-            ],
-            "name": "invalidateReporter",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "lowerBoundAnchorRatio",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "maxTokens",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "newObservations",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "timestamp",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "acc",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "numTokens",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "oldObservations",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "timestamp",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "acc",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes[]",
-                    "name": "messages",
-                    "type": "bytes[]"
-                },
-                {
-                    "internalType": "bytes[]",
-                    "name": "signatures",
-                    "type": "bytes[]"
-                },
-                {
-                    "internalType": "string[]",
-                    "name": "symbols",
-                    "type": "string[]"
-                }
-            ],
-            "name": "postPrices",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "string",
-                    "name": "symbol",
-                    "type": "string"
-                }
-            ],
-            "name": "price",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "priceData",
-            "outputs": [
-                {
-                    "internalType": "contract OpenOraclePriceData",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes32",
-                    "name": "",
-                    "type": "bytes32"
-                }
-            ],
-            "name": "prices",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "reporter",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "reporterInvalidated",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "bytes",
-                    "name": "message",
-                    "type": "bytes"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
-                }
-            ],
-            "name": "source",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "pure",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "upperBoundAnchorRatio",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        }
-    ],
-    "LegacyJumpRateModelV2": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event",
-            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf14039de"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xa385fb96"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x15f24053"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb8168816"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x2191f92a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jumpMultiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb9f9850a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xfd2da339"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8726bb89"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8da5cb5b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                }
-            ],
-            "name": "updateJumpRateModel",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x2037f3e7"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function",
-            "signature": "0x6e71e2d8"
-        }
-    ],
-    "JumpRateModelV2": [
-        {
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-            "signature": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "baseRatePerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "multiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerBlock",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "kink",
-                    "type": "uint256"
-                }
-            ],
-            "name": "NewInterestParams",
-            "type": "event",
-            "signature": "0x6960ab234c7ef4b0c9197100f5393cfcde7c453ac910a27bd2000aa1dd4c068d"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "baseRatePerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xf14039de"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "blocksPerYear",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xa385fb96"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getBorrowRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x15f24053"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserveFactorMantissa",
-                    "type": "uint256"
-                }
-            ],
-            "name": "getSupplyRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb8168816"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "isInterestRateModel",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x2191f92a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "jumpMultiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xb9f9850a"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "kink",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0xfd2da339"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "multiplierPerBlock",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8726bb89"
-        },
-        {
-            "constant": true,
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function",
-            "signature": "0x8da5cb5b"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "baseRatePerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "multiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "jumpMultiplierPerYear",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "kink_",
-                    "type": "uint256"
-                }
-            ],
-            "name": "updateJumpRateModel",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function",
-            "signature": "0x2037f3e7"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "cash",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "borrows",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "reserves",
-                    "type": "uint256"
-                }
-            ],
-            "name": "utilizationRate",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "pure",
-            "type": "function",
-            "signature": "0x6e71e2d8"
-        }
-    ],
-    "CrowdProposalFactory": [
-        {
-            "inputs": [
                 {
                     "internalType": "address",
                     "name": "comp_",
@@ -43753,17 +41454,224 @@
                 },
                 {
                     "internalType": "address",
-                    "name": "governor_",
+                    "name": "admin_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "implementation_",
                     "type": "address"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "compStakeAmount_",
+                    "name": "votingPeriod_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "votingDelay_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "proposalThreshold_",
                     "type": "uint256"
                 }
             ],
+            "payable": false,
             "stateMutability": "nonpayable",
-            "type": "constructor"
+            "type": "constructor",
+            "signature": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldImplementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "NewImplementation",
+            "type": "event",
+            "signature": "0xd604de94d45953f9138079ec1b82d533cb2160c906d1076d1f7ed54befbca97a"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalCanceled",
+            "type": "event",
+            "signature": "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "ProposalCreated",
+            "type": "event",
+            "signature": "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalExecuted",
+            "type": "event",
+            "signature": "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "eta",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalQueued",
+            "type": "event",
+            "signature": "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldProposalThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newProposalThreshold",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalThresholdSet",
+            "type": "event",
+            "signature": "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461"
         },
         {
             "anonymous": false,
@@ -43771,52 +41679,103 @@
                 {
                     "indexed": true,
                     "internalType": "address",
-                    "name": "proposal",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "author",
+                    "name": "voter",
                     "type": "address"
                 },
                 {
                     "indexed": false,
-                    "internalType": "address[]",
-                    "name": "targets",
-                    "type": "address[]"
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
                 },
                 {
                     "indexed": false,
-                    "internalType": "uint256[]",
-                    "name": "values",
-                    "type": "uint256[]"
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
                 },
                 {
                     "indexed": false,
-                    "internalType": "string[]",
-                    "name": "signatures",
-                    "type": "string[]"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "bytes[]",
-                    "name": "calldatas",
-                    "type": "bytes[]"
+                    "internalType": "uint256",
+                    "name": "votes",
+                    "type": "uint256"
                 },
                 {
                     "indexed": false,
                     "internalType": "string",
-                    "name": "description",
+                    "name": "reason",
                     "type": "string"
                 }
             ],
-            "name": "CrowdProposalCreated",
-            "type": "event"
+            "name": "VoteCast",
+            "type": "event",
+            "signature": "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4"
         },
         {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVotingDelay",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVotingDelay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VotingDelaySet",
+            "type": "event",
+            "signature": "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVotingPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVotingPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VotingPeriodSet",
+            "type": "event",
+            "signature": "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828"
+        },
+        {
+            "payable": true,
+            "stateMutability": "payable",
+            "type": "fallback"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "implementation_",
+                    "type": "address"
+                }
+            ],
+            "name": "_setImplementation",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xbb913f41"
+        },
+        {
+            "constant": true,
             "inputs": [],
-            "name": "comp",
+            "name": "admin",
             "outputs": [
                 {
                     "internalType": "address",
@@ -43824,12 +41783,79 @@
                     "type": "address"
                 }
             ],
+            "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xf851a440"
         },
         {
+            "constant": true,
             "inputs": [],
-            "name": "compStakeAmount",
+            "name": "implementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x5c60da1b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x26782247"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "BALLOT_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdeaaa7cc"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "DOMAIN_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x20606b70"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "MIN_PROPOSAL_THRESHOLD",
             "outputs": [
                 {
                     "internalType": "uint256",
@@ -43837,10 +41863,520 @@
                     "type": "uint256"
                 }
             ],
+            "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0x791f5d23"
         },
         {
+            "constant": false,
+            "inputs": [],
+            "name": "_acceptAdmin",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe9c714f2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "governorAlpha",
+                    "type": "address"
+                }
+            ],
+            "name": "_initiate",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xf9d28b80"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPendingAdmin",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xb71d1a0c"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newProposalThereshold",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setProposalThreshold",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x17ba1b8b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newVotingDelay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setVotingDelay",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1dfb1b5a"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newVotingPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setVotingPeriod",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x0ea2d98c"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "cancel",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x40e58ee5"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                }
+            ],
+            "name": "castVote",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x56781388"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "castVoteBySig",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x3bccf4fd"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "string",
+                    "name": "reason",
+                    "type": "string"
+                }
+            ],
+            "name": "castVoteWithReason",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x7b3c71d3"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "comp",
+            "outputs": [
+                {
+                    "internalType": "contract CompInterface",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x109d0af8"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "execute",
+            "outputs": [],
+            "payable": true,
+            "stateMutability": "payable",
+            "type": "function",
+            "signature": "0xfe0d94c1"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getActions",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x328dd982"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "voter",
+                    "type": "address"
+                }
+            ],
+            "name": "getReceipt",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bool",
+                            "name": "hasVoted",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "support",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint96",
+                            "name": "votes",
+                            "type": "uint96"
+                        }
+                    ],
+                    "internalType": "struct GovernorBravoDelegateStorageV1.Receipt",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xe23a9a52"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "initalProposalId",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x51642a0d"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "timelock_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "comp_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "votingPeriod_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "votingDelay_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "proposalThreshold_",
+                    "type": "uint256"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd13f90b4"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "latestProposalIds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x17977c61"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x06fdde03"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalCount",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xda35c664"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalMaxOperations",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x7bdbe4d0"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalThreshold",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb58131b0"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "proposals",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "eta",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "startBlock",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "forVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "againstVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "abstainVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "canceled",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "executed",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x013cf08b"
+        },
+        {
+            "constant": false,
             "inputs": [
                 {
                     "internalType": "address[]",
@@ -43868,14 +42404,533 @@
                     "type": "string"
                 }
             ],
-            "name": "createCrowdProposal",
-            "outputs": [],
+            "name": "propose",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
             "stateMutability": "nonpayable",
-            "type": "function"
+            "type": "function",
+            "signature": "0xda95691a"
         },
         {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "queue",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xddf0b009"
+        },
+        {
+            "constant": true,
             "inputs": [],
-            "name": "governor",
+            "name": "quorumVotes",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x24bc1a64"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "state",
+            "outputs": [
+                {
+                    "internalType": "enum GovernorBravoDelegateStorageV1.ProposalState",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3e4f49e6"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "timelock",
+            "outputs": [
+                {
+                    "internalType": "contract TimelockInterface",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xd33219b4"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "votingDelay",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3932abb1"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "votingPeriod",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x02a251a3"
+        }
+    ],
+    "GovernorBravoDelegate": [
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldImplementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "NewImplementation",
+            "type": "event",
+            "signature": "0xd604de94d45953f9138079ec1b82d533cb2160c906d1076d1f7ed54befbca97a"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalCanceled",
+            "type": "event",
+            "signature": "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "ProposalCreated",
+            "type": "event",
+            "signature": "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalExecuted",
+            "type": "event",
+            "signature": "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "eta",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalQueued",
+            "type": "event",
+            "signature": "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldProposalThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newProposalThreshold",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalThresholdSet",
+            "type": "event",
+            "signature": "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "voter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "votes",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "reason",
+                    "type": "string"
+                }
+            ],
+            "name": "VoteCast",
+            "type": "event",
+            "signature": "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVotingDelay",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVotingDelay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VotingDelaySet",
+            "type": "event",
+            "signature": "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldVotingPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newVotingPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VotingPeriodSet",
+            "type": "event",
+            "signature": "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "BALLOT_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xdeaaa7cc"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "DOMAIN_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x20606b70"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "MIN_PROPOSAL_THRESHOLD",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x791f5d23"
+        },
+        {
+            "constant": false,
+            "inputs": [],
+            "name": "_acceptAdmin",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xe9c714f2"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "governorAlpha",
+                    "type": "address"
+                }
+            ],
+            "name": "_initiate",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xf9d28b80"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "_setPendingAdmin",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xb71d1a0c"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newProposalThereshold",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setProposalThreshold",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x17ba1b8b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newVotingDelay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setVotingDelay",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x1dfb1b5a"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newVotingPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "_setVotingPeriod",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x0ea2d98c"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "admin",
             "outputs": [
                 {
                     "internalType": "address",
@@ -43883,8 +42938,2445 @@
                     "type": "address"
                 }
             ],
+            "payable": false,
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
+            "signature": "0xf851a440"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "cancel",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x40e58ee5"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                }
+            ],
+            "name": "castVote",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x56781388"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "castVoteBySig",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x3bccf4fd"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "support",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "string",
+                    "name": "reason",
+                    "type": "string"
+                }
+            ],
+            "name": "castVoteWithReason",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0x7b3c71d3"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "comp",
+            "outputs": [
+                {
+                    "internalType": "contract CompInterface",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x109d0af8"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "execute",
+            "outputs": [],
+            "payable": true,
+            "stateMutability": "payable",
+            "type": "function",
+            "signature": "0xfe0d94c1"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getActions",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x328dd982"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "voter",
+                    "type": "address"
+                }
+            ],
+            "name": "getReceipt",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bool",
+                            "name": "hasVoted",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "support",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint96",
+                            "name": "votes",
+                            "type": "uint96"
+                        }
+                    ],
+                    "internalType": "struct GovernorBravoDelegateStorageV1.Receipt",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xe23a9a52"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "implementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x5c60da1b"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "initalProposalId",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x51642a0d"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "timelock_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "comp_",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "votingPeriod_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "votingDelay_",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "proposalThreshold_",
+                    "type": "uint256"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xd13f90b4"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "latestProposalIds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x17977c61"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x06fdde03"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "pendingAdmin",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x26782247"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalCount",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xda35c664"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalMaxOperations",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x7bdbe4d0"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "proposalThreshold",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xb58131b0"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "proposals",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "eta",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "startBlock",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "forVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "againstVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "abstainVotes",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "canceled",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "executed",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x013cf08b"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "propose",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xda95691a"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "queue",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+            "signature": "0xddf0b009"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "quorumVotes",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function",
+            "signature": "0x24bc1a64"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "state",
+            "outputs": [
+                {
+                    "internalType": "enum GovernorBravoDelegateStorageV1.ProposalState",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3e4f49e6"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "timelock",
+            "outputs": [
+                {
+                    "internalType": "contract TimelockInterface",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0xd33219b4"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "votingDelay",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x3932abb1"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "votingPeriod",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+            "signature": "0x02a251a3"
+        }
+    ],
+    "LINK": [
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"name",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"string"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_spender",
+                 "type":"address"
+              },
+              {
+                 "name":"_value",
+                 "type":"uint256"
+              }
+           ],
+           "name":"approve",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"totalSupply",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_from",
+                 "type":"address"
+              },
+              {
+                 "name":"_to",
+                 "type":"address"
+              },
+              {
+                 "name":"_value",
+                 "type":"uint256"
+              }
+           ],
+           "name":"transferFrom",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"decimals",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"uint8"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_to",
+                 "type":"address"
+              },
+              {
+                 "name":"_value",
+                 "type":"uint256"
+              },
+              {
+                 "name":"_data",
+                 "type":"bytes"
+              }
+           ],
+           "name":"transferAndCall",
+           "outputs":[
+              {
+                 "name":"success",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_spender",
+                 "type":"address"
+              },
+              {
+                 "name":"_subtractedValue",
+                 "type":"uint256"
+              }
+           ],
+           "name":"decreaseApproval",
+           "outputs":[
+              {
+                 "name":"success",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "name":"_owner",
+                 "type":"address"
+              }
+           ],
+           "name":"balanceOf",
+           "outputs":[
+              {
+                 "name":"balance",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"symbol",
+           "outputs":[
+              {
+                 "name":"",
+                 "type":"string"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_to",
+                 "type":"address"
+              },
+              {
+                 "name":"_value",
+                 "type":"uint256"
+              }
+           ],
+           "name":"transfer",
+           "outputs":[
+              {
+                 "name":"success",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "name":"_spender",
+                 "type":"address"
+              },
+              {
+                 "name":"_addedValue",
+                 "type":"uint256"
+              }
+           ],
+           "name":"increaseApproval",
+           "outputs":[
+              {
+                 "name":"success",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "name":"_owner",
+                 "type":"address"
+              },
+              {
+                 "name":"_spender",
+                 "type":"address"
+              }
+           ],
+           "name":"allowance",
+           "outputs":[
+              {
+                 "name":"remaining",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "inputs":[
+              
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"constructor"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":true,
+                 "name":"from",
+                 "type":"address"
+              },
+              {
+                 "indexed":true,
+                 "name":"to",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "name":"value",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "name":"data",
+                 "type":"bytes"
+              }
+           ],
+           "name":"Transfer",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":true,
+                 "name":"owner",
+                 "type":"address"
+              },
+              {
+                 "indexed":true,
+                 "name":"spender",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "name":"value",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Approval",
+           "type":"event"
+        }
+    ],
+    "cLINK": [
+        {
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"underlying_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"contract ComptrollerInterface",
+                 "name":"comptroller_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"contract InterestRateModel",
+                 "name":"interestRateModel_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"initialExchangeRateMantissa_",
+                 "type":"uint256"
+              },
+              {
+                 "internalType":"string",
+                 "name":"name_",
+                 "type":"string"
+              },
+              {
+                 "internalType":"string",
+                 "name":"symbol_",
+                 "type":"string"
+              },
+              {
+                 "internalType":"uint8",
+                 "name":"decimals_",
+                 "type":"uint8"
+              },
+              {
+                 "internalType":"address payable",
+                 "name":"admin_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"address",
+                 "name":"implementation_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"bytes",
+                 "name":"becomeImplementationData",
+                 "type":"bytes"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"constructor"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"cashPrior",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"interestAccumulated",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"borrowIndex",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"totalBorrows",
+                 "type":"uint256"
+              }
+           ],
+           "name":"AccrueInterest",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":true,
+                 "internalType":"address",
+                 "name":"owner",
+                 "type":"address"
+              },
+              {
+                 "indexed":true,
+                 "internalType":"address",
+                 "name":"spender",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"amount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Approval",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"borrowAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"accountBorrows",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"totalBorrows",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Borrow",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"error",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"info",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"detail",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Failure",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"liquidator",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"repayAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"cTokenCollateral",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"seizeTokens",
+                 "type":"uint256"
+              }
+           ],
+           "name":"LiquidateBorrow",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"minter",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"mintAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"mintTokens",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Mint",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"oldAdmin",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"newAdmin",
+                 "type":"address"
+              }
+           ],
+           "name":"NewAdmin",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"contract ComptrollerInterface",
+                 "name":"oldComptroller",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"contract ComptrollerInterface",
+                 "name":"newComptroller",
+                 "type":"address"
+              }
+           ],
+           "name":"NewComptroller",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"oldImplementation",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"newImplementation",
+                 "type":"address"
+              }
+           ],
+           "name":"NewImplementation",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"contract InterestRateModel",
+                 "name":"oldInterestRateModel",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"contract InterestRateModel",
+                 "name":"newInterestRateModel",
+                 "type":"address"
+              }
+           ],
+           "name":"NewMarketInterestRateModel",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"oldPendingAdmin",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"newPendingAdmin",
+                 "type":"address"
+              }
+           ],
+           "name":"NewPendingAdmin",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"oldReserveFactorMantissa",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"newReserveFactorMantissa",
+                 "type":"uint256"
+              }
+           ],
+           "name":"NewReserveFactor",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"redeemer",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"redeemAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"redeemTokens",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Redeem",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"payer",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"repayAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"accountBorrows",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"totalBorrows",
+                 "type":"uint256"
+              }
+           ],
+           "name":"RepayBorrow",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"benefactor",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"addAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"newTotalReserves",
+                 "type":"uint256"
+              }
+           ],
+           "name":"ReservesAdded",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":false,
+                 "internalType":"address",
+                 "name":"admin",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"reduceAmount",
+                 "type":"uint256"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"newTotalReserves",
+                 "type":"uint256"
+              }
+           ],
+           "name":"ReservesReduced",
+           "type":"event"
+        },
+        {
+           "anonymous":false,
+           "inputs":[
+              {
+                 "indexed":true,
+                 "internalType":"address",
+                 "name":"from",
+                 "type":"address"
+              },
+              {
+                 "indexed":true,
+                 "internalType":"address",
+                 "name":"to",
+                 "type":"address"
+              },
+              {
+                 "indexed":false,
+                 "internalType":"uint256",
+                 "name":"amount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"Transfer",
+           "type":"event"
+        },
+        {
+           "payable":true,
+           "stateMutability":"payable",
+           "type":"fallback"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              
+           ],
+           "name":"_acceptAdmin",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"addAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"_addReserves",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"reduceAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"_reduceReserves",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"contract ComptrollerInterface",
+                 "name":"newComptroller",
+                 "type":"address"
+              }
+           ],
+           "name":"_setComptroller",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"implementation_",
+                 "type":"address"
+              },
+              {
+                 "internalType":"bool",
+                 "name":"allowResign",
+                 "type":"bool"
+              },
+              {
+                 "internalType":"bytes",
+                 "name":"becomeImplementationData",
+                 "type":"bytes"
+              }
+           ],
+           "name":"_setImplementation",
+           "outputs":[
+              
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"contract InterestRateModel",
+                 "name":"newInterestRateModel",
+                 "type":"address"
+              }
+           ],
+           "name":"_setInterestRateModel",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address payable",
+                 "name":"newPendingAdmin",
+                 "type":"address"
+              }
+           ],
+           "name":"_setPendingAdmin",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"newReserveFactorMantissa",
+                 "type":"uint256"
+              }
+           ],
+           "name":"_setReserveFactor",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"accrualBlockNumber",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              
+           ],
+           "name":"accrueInterest",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"admin",
+           "outputs":[
+              {
+                 "internalType":"address payable",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"owner",
+                 "type":"address"
+              },
+              {
+                 "internalType":"address",
+                 "name":"spender",
+                 "type":"address"
+              }
+           ],
+           "name":"allowance",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"spender",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"amount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"approve",
+           "outputs":[
+              {
+                 "internalType":"bool",
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"owner",
+                 "type":"address"
+              }
+           ],
+           "name":"balanceOf",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"owner",
+                 "type":"address"
+              }
+           ],
+           "name":"balanceOfUnderlying",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"borrowAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"borrow",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"account",
+                 "type":"address"
+              }
+           ],
+           "name":"borrowBalanceCurrent",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"account",
+                 "type":"address"
+              }
+           ],
+           "name":"borrowBalanceStored",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"borrowIndex",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"borrowRatePerBlock",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"comptroller",
+           "outputs":[
+              {
+                 "internalType":"contract ComptrollerInterface",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"decimals",
+           "outputs":[
+              {
+                 "internalType":"uint8",
+                 "name":"",
+                 "type":"uint8"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"bytes",
+                 "name":"data",
+                 "type":"bytes"
+              }
+           ],
+           "name":"delegateToImplementation",
+           "outputs":[
+              {
+                 "internalType":"bytes",
+                 "name":"",
+                 "type":"bytes"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "internalType":"bytes",
+                 "name":"data",
+                 "type":"bytes"
+              }
+           ],
+           "name":"delegateToViewImplementation",
+           "outputs":[
+              {
+                 "internalType":"bytes",
+                 "name":"",
+                 "type":"bytes"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              
+           ],
+           "name":"exchangeRateCurrent",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"exchangeRateStored",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"account",
+                 "type":"address"
+              }
+           ],
+           "name":"getAccountSnapshot",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"getCash",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"implementation",
+           "outputs":[
+              {
+                 "internalType":"address",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"interestRateModel",
+           "outputs":[
+              {
+                 "internalType":"contract InterestRateModel",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"isCToken",
+           "outputs":[
+              {
+                 "internalType":"bool",
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"repayAmount",
+                 "type":"uint256"
+              },
+              {
+                 "internalType":"contract CTokenInterface",
+                 "name":"cTokenCollateral",
+                 "type":"address"
+              }
+           ],
+           "name":"liquidateBorrow",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"mintAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"mint",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"name",
+           "outputs":[
+              {
+                 "internalType":"string",
+                 "name":"",
+                 "type":"string"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"pendingAdmin",
+           "outputs":[
+              {
+                 "internalType":"address payable",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"redeemTokens",
+                 "type":"uint256"
+              }
+           ],
+           "name":"redeem",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"redeemAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"redeemUnderlying",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"repayAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"repayBorrow",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"repayAmount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"repayBorrowBehalf",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"reserveFactorMantissa",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"liquidator",
+                 "type":"address"
+              },
+              {
+                 "internalType":"address",
+                 "name":"borrower",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"seizeTokens",
+                 "type":"uint256"
+              }
+           ],
+           "name":"seize",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"supplyRatePerBlock",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"contract EIP20NonStandardInterface",
+                 "name":"token",
+                 "type":"address"
+              }
+           ],
+           "name":"sweepToken",
+           "outputs":[
+              
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"symbol",
+           "outputs":[
+              {
+                 "internalType":"string",
+                 "name":"",
+                 "type":"string"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"totalBorrows",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              
+           ],
+           "name":"totalBorrowsCurrent",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"totalReserves",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"totalSupply",
+           "outputs":[
+              {
+                 "internalType":"uint256",
+                 "name":"",
+                 "type":"uint256"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"dst",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"amount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"transfer",
+           "outputs":[
+              {
+                 "internalType":"bool",
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":false,
+           "inputs":[
+              {
+                 "internalType":"address",
+                 "name":"src",
+                 "type":"address"
+              },
+              {
+                 "internalType":"address",
+                 "name":"dst",
+                 "type":"address"
+              },
+              {
+                 "internalType":"uint256",
+                 "name":"amount",
+                 "type":"uint256"
+              }
+           ],
+           "name":"transferFrom",
+           "outputs":[
+              {
+                 "internalType":"bool",
+                 "name":"",
+                 "type":"bool"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"nonpayable",
+           "type":"function"
+        },
+        {
+           "constant":true,
+           "inputs":[
+              
+           ],
+           "name":"underlying",
+           "outputs":[
+              {
+                 "internalType":"address",
+                 "name":"",
+                 "type":"address"
+              }
+           ],
+           "payable":false,
+           "stateMutability":"view",
+           "type":"function"
         }
     ]
 }

--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -72,7 +72,8 @@
         "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "DSR_Updateable": "0xfeD941d39905B23D6FAf02C8301d40bD4834E27F",
         "GovernorBravoDelegator": "0xc0da02939e1441f497fd74f78ce7decb17b66529",
-        "GovernorBravoDelegate": "0xAAAaaAAAaaaa8FdB04F544F4EEe52939CddCe378"
+        "GovernorBravoDelegate": "0xAAAaaAAAaaaa8FdB04F544F4EEe52939CddCe378",
+        "cLINK": "0xface851a4921ce59e912d19329929ce6da6eb0c7"
     },
     "Blocks": {
         "cUSDC": 7710760,
@@ -122,7 +123,8 @@
         "cWBTC": 8163813,
         "DSR_Updateable": 10504587,
         "GovernorBravoDelegator": 12006099,
-        "GovernorBravoDelegate": 12005518
+        "GovernorBravoDelegate": 12005518,
+        "cLINK": 12286030
     },
     "PriceFeed": {
         "description": "Open Oracle Uniswap Anchored View + UNI",
@@ -483,6 +485,15 @@
             "contract": "CErc20",
             "initial_exchange_rate_mantissa": "20000000000000000",
             "address": "0xC11b1268C1A384e55C48c2391d8d480264A3A7F4"
+        },
+        "cLINK": {
+            "name": "Compound ChainLink Token",
+            "symbol": "cLINK",
+            "decimals": 8,
+            "underlying": "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "contract": "CErc20Delegator",
+            "initial_exchange_rate_mantissa": "200000000000000000000000000",
+            "address": "0xFAce851a4921ce59e912d19329929CE6da6EB0c7"
         }
     },
     "InterestRateModel": {

--- a/spec/sim/0010-clink-integration/hypothetical_clink_integration.scen
+++ b/spec/sim/0010-clink-integration/hypothetical_clink_integration.scen
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S yarn repl -s
+
+PrintTransactionLogs
+
+-- Token holder addresses for mocking
+Alias CompHolder "0x7587caefc8096f5f40acb83a09df031a018c66ec"
+Alias LinkHolder "0x98c63b7b319dfbdf3d811530f2ab9dfe4983af9d"
+Alias CUSDCHolder "0x5e34bc93a7506ecc8562ade4d5c8b090247a6349"
+
+Web3Fork "https://mainnet-eth.compound.finance/@12343387" (CompHolder LinkHolder CUSDCHolder)
+UseConfigs mainnet
+
+-- Delegate and propose update
+From CompHolder (Comp Delegate CompHolder)
+From CompHolder (GovernorBravo GovernorBravoDelegator Propose "Add LINK Market" [(Address Comptroller) (Address Comptroller) (Address Comptroller) (Address Comptroller) (Address Comptroller) (Address Comptroller) (Address cLINK)] [0 0 0 0 0 0 0] ["_supportMarket(address)" "_setCollateralFactor(address,uint256)" "_setCompSpeed(address,uint256)" "_setCompSpeed(address,uint256)" "_setCompSpeed(address,uint256)" "_setCompSpeed(address,uint256)" "_setReserveFactor(uint256)"] [[(address cLINK)] [(address cLINK) 0] [(address cLINK) 1462500000000000] [(address cBAT) 1462500000000000] [(address cUNI) 1462500000000000] [(address cZRX) 1462500000000000] [250000000000000000]])
+
+-- Fast forward, vote, queue, execute
+MineBlock
+AdvanceBlocks 14000
+From CompHolder (GovernorBravo GovernorBravoDelegator Proposal LastProposal Vote For)
+AdvanceBlocks 20000
+GovernorBravo GovernorBravoDelegator Proposal LastProposal Queue
+IncreaseTime 604910
+GovernorBravo GovernorBravoDelegator Proposal LastProposal Execute
+
+-- Assert cLINK market supported
+Assert True (Comptroller CheckListed cLINK)
+
+-- Ensure accrue interest works
+CToken cLINK AccrueInterest
+
+-- Mint test
+From LinkHolder (Erc20 LINK Approve (Address cLINK) 10e18)
+From LinkHolder (CToken cLINK Mint 10e18)
+Assert Equal (Erc20 LINK TokenBalance LinkHolder) (350000011777777777777777777)
+Assert Equal (Erc20 LINK TokenBalance cLINK) (10e18)
+
+-- Borrow test
+From CUSDCHolder (CToken cLINK Borrow 1e18)
+Assert Equal (Erc20 LINK TokenBalance CUSDCHolder) (1e18)
+Assert Equal (Erc20 LINK TokenBalance cLINK) (9e18)
+
+-- Repay borrow test
+From CUSDCHolder (Erc20 LINK Approve (Address cLINK) 1e18)
+From CUSDCHolder (CToken cLINK RepayBorrow 1e18)
+Assert Equal (Erc20 LINK TokenBalance CUSDCHolder) (0)
+Assert Equal (Erc20 LINK TokenBalance cLINK) (10e18)
+
+-- Redeem test (note: 50 cLINK == 1 LINK initially)
+From LinkHolder (CToken cLINK Redeem 50e8)
+
+Print "cLINK integration ok"


### PR DESCRIPTION
This PR adds support for cLINK.
- Add mainnet definitions in mainnet.json
- Replace mainnet-abi.json with [Ar00's latest version](https://github.com/Arr00-Blurr/compound-protocol/blob/0d8abda1ddb4fe09554a4c74704b6126f32d33e5/networks/mainnet-abi.json)
- Add LINK and cLINK ABIs to mainnet-abi.json
- Add cLINK integration scenario covering proposal, interest accrual, minting, borrowing, repaying, and redeeming