### PR TITLE
Standardize line endings to Unix-style LF, except for PDFs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text eol=lf
+*.pdf binary
 *.sol linguist-language=Solidity


### PR DESCRIPTION
Getty had problems where git changed line endings to CRLF which broke all of the bash scripts.

This merge request modifies .gitattributes to ensure that all text files other than PDFs use LF, remedying this problem.