### PR TITLE
WIP: Upgrade Comptroller to use dynamic COMP reward distribution

### DIFF
--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -143,3 +143,13 @@ contract ComptrollerV5Storage is ComptrollerV4Storage {
     /// @notice Last block at which a contributor's COMP rewards have been allocated
     mapping(address => uint) public lastContributorBlock;
 }
+
+contract ComptrollerV6Storage is ComptrollerV5Storage {
+    /**
+     * @notice Maps each market to a distrubition ratio [0, 1000] of the comp rewards for borrowers vs suppliers.
+     *  A value of 1000 means all of the COMP rewards for the market goes to borrowers whereas 0 means all rewards goes to suppliers.
+     * @dev These ratios are incremented by 1 to reserve 0 as being uninitialized, giving an underlying range of [1, 1001].
+     *  Subtract 1 to get the real ratio in the range of [0, 1000].
+     */
+    mapping(address => uint16) public compRewardDistributionRatios;
+}

--- a/tests/Contracts/ComptrollerHarness.sol
+++ b/tests/Contracts/ComptrollerHarness.sol
@@ -83,7 +83,7 @@ contract ComptrollerHarness is Comptroller {
         for (uint i = 0; i < allMarkets_.length; i++) {
             CToken cToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(compRate, div_(utilities[i], totalUtility)) : 0;
-            setCompSpeedInternal(cToken, newSpeed);
+            setCompSpeedInternal(cToken, newSpeed, 500);
         }
     }
 
@@ -131,7 +131,7 @@ contract ComptrollerHarness is Comptroller {
     function harnessAddCompMarkets(address[] memory cTokens) public {
         for (uint i = 0; i < cTokens.length; i++) {
             // temporarily set compSpeed to 1 (will be fixed by `harnessRefreshCompSpeeds`)
-            setCompSpeedInternal(CToken(cTokens[i]), 1);
+            setCompSpeedInternal(CToken(cTokens[i]), 1, 500);
         }
     }
 

--- a/tests/Contracts/ComptrollerScenario.sol
+++ b/tests/Contracts/ComptrollerScenario.sol
@@ -65,7 +65,7 @@ contract ComptrollerScenario is Comptroller {
         for (uint i = 0; i < allMarkets_.length; i++) {
             CToken cToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(compRate, div_(utilities[i], totalUtility)) : 0;
-            setCompSpeedInternal(cToken, newSpeed);
+            setCompSpeedInternal(cToken, newSpeed, 500);
         }
     }
 }


### PR DESCRIPTION
- For RFP 16: Dynamic COMP reward distribution
- Uses a ratio in the range of [0, 1000] for each market (stored in uint16) to determine how much of the COMP rewards go to borrowers vs. suppliers.
- A value of 1000 means all of the COMP rewards for the market goes to borrowers whereas 0 means all rewards go to suppliers.
- In the underlying data structure, the actual range is [0, 1001] to reserve 0 as uninitialized (uses the old COMP rewards distribution strategy).
- All markets start off as uninitialized (uses the old 50/50 distribution strategy).
- Adds public _setCompDistributionRatio and _setCompSpeedAndDistributionRatio (uses a range of [0, 1000]; incremented by 1 to signal the ratio is initialized).
- Calling the above functions with a ratio value of 500 will result in the same 50/50 distribution strategy we currently use
- Test contracts have been updated to use a ratio value of 500.
- A new event type - CompDistributionRatioUpdated - has been added (range of [0, 1001] to include uninitialized ratios (0))