### PR TITLE
Changed SimplePriceOracle so ETH price can be set on testnets

### DIFF
--- a/contracts/SimplePriceOracle.sol
+++ b/contracts/SimplePriceOracle.sol
@@ -7,16 +7,22 @@ contract SimplePriceOracle is PriceOracle {
     mapping(address => uint) prices;
     event PricePosted(address asset, uint previousPriceMantissa, uint requestedPriceMantissa, uint newPriceMantissa);
 
-    function getUnderlyingPrice(CToken cToken) public view returns (uint) {
+    function _getUnderlyingAddress(CToken cToken) private view returns (address) {
+        address asset;
         if (compareStrings(cToken.symbol(), "cETH")) {
-            return 1e18;
+            asset = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
         } else {
-            return prices[address(CErc20(address(cToken)).underlying())];
+            asset = address(CErc20(address(cToken)).underlying());
         }
+        return asset;
+    }
+
+    function getUnderlyingPrice(CToken cToken) public view returns (uint) {
+        return prices[_getUnderlyingAddress(cToken)];
     }
 
     function setUnderlyingPrice(CToken cToken, uint underlyingPriceMantissa) public {
-        address asset = address(CErc20(address(cToken)).underlying());
+        address asset = _getUnderlyingAddress(cToken);
         emit PricePosted(asset, prices[asset], underlyingPriceMantissa, underlyingPriceMantissa);
         prices[asset] = underlyingPriceMantissa;
     }

--- a/networks/ropsten.json
+++ b/networks/ropsten.json
@@ -61,7 +61,8 @@
         "cZRX": "0x6B8b0D7875B4182Fb126877023fB93b934dD302A",
         "cWBTC": "0x541c9cB0E97b77F142684cc33E8AC9aC17B1990F",
         "USDC": "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
-        "ComptrollerRopsten": "0x1435b33741523dd5BB99f8FD8Dc00cF926fE96Fb"
+        "ComptrollerRopsten": "0x1435b33741523dd5BB99f8FD8Dc00cF926fE96Fb",
+        "SimplePriceOracle": "0x7BBF806F69ea21Ea9B8Af061AD0C1c41913063A1"
     },
     "Blocks": {
         "ComptrollerG8": 10279074,

--- a/tests/Lens/CompoundLensTest.js
+++ b/tests/Lens/CompoundLensTest.js
@@ -204,7 +204,7 @@ describe('CompoundLens', () => {
       ).toEqual(
         {
           cToken: cEth._address,
-          underlyingPrice: "1000000000000000000",
+          underlyingPrice: "0",
         }
       );
     });
@@ -223,7 +223,7 @@ describe('CompoundLens', () => {
         },
         {
           cToken: cEth._address,
-          underlyingPrice: "1000000000000000000",
+          underlyingPrice: "0",
         }
       ]);
     });


### PR DESCRIPTION
Changes for the Ropsten testnet price feed. ETH price can now be set.

```
saddle deploy -n ropsten SimplePriceOracle
saddle verify -n ropsten $ETHERSCAN_API_KEY 0x7BBF806F69ea21Ea9B8Af061AD0C1c41913063A1 SimplePriceOracle
```