### PR TITLE
Improve security of Comptroller#_supportMarket

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -929,7 +929,9 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterface, ComptrollerE
       * @return uint 0=success, otherwise a failure. (See enum Error for details)
       */
     function _supportMarket(CToken cToken) external returns (uint) {
-        if (msg.sender != admin) {
+        // 1. Ensure the sender is the admin of the Comptroller
+        // 2. Ensure the admin of the cToken is the admin of the Comptroller
+        if (/* 1. */ msg.sender != admin || /* 2. */ cToken.admin != admin) {
             return fail(Error.UNAUTHORIZED, FailureInfo.SUPPORT_MARKET_OWNER_CHECK);
         }
 


### PR DESCRIPTION
Adds an additional check to ensure that the admin of the cToken is the same as the admin of the Comptroller when supporting a new market.

Test status: in-progress