### PR TITLE
Add in-queue check for cancelTransaction() in Timelock.sol

### DIFF
--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -73,6 +73,8 @@ contract Timelock {
         require(msg.sender == admin, "Timelock::cancelTransaction: Call must come from admin.");
 
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
+
         queuedTransactions[txHash] = false;
 
         emit CancelTransaction(txHash, target, value, signature, data, eta);

--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -70,7 +70,7 @@ contract Timelock {
         require(msg.sender == admin, "Timelock::cancelTransaction: Call must come from admin.");
 
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
-        require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
+        require(queuedTransactions[txHash], "Timelock::cancelTransaction: Transaction hasn't been queued.");
 
         queuedTransactions[txHash] = false;
 


### PR DESCRIPTION
Add in-queue check for cancelTransaction() in Timelock.sol :

```solidity
        require(queuedTransactions[txHash], "Timelock::cancelTransaction: Transaction hasn't been queued.");
```

before deleting the transaction from the queue:
```solidity
        queuedTransactions[txHash] = false;
```

Link to #214 