### PR TITLE
Fix in documentation description - details about number of decimals in returned value.

### DIFF
--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -269,7 +269,7 @@ abstract contract CToken is CTokenInterface, ExponentialNoError, TokenErrorRepor
 
     /**
      * @notice Accrue interest then return the up-to-date exchange rate
-     * @return Calculated exchange rate scaled by 1e18
+     * @return Calculated exchange rate scaled by 10**(Underlying Token Decimals + 18 - CToken Decimals)
      */
     function exchangeRateCurrent() override public nonReentrant returns (uint) {
         accrueInterest();
@@ -279,7 +279,7 @@ abstract contract CToken is CTokenInterface, ExponentialNoError, TokenErrorRepor
     /**
      * @notice Calculates the exchange rate from the underlying to the CToken
      * @dev This function does not accrue interest before calculating the exchange rate
-     * @return Calculated exchange rate scaled by 1e18
+     * @return Calculated exchange rate scaled by 10**(Underlying Token Decimals + 18 - CToken Decimals)
      */
     function exchangeRateStored() override public view returns (uint) {
         return exchangeRateStoredInternal();
@@ -288,7 +288,7 @@ abstract contract CToken is CTokenInterface, ExponentialNoError, TokenErrorRepor
     /**
      * @notice Calculates the exchange rate from the underlying to the CToken
      * @dev This function does not accrue interest before calculating the exchange rate
-     * @return calculated exchange rate scaled by 1e18
+     * @return calculated exchange rate scaled by 10**(Underlying Token Decimals + 18 - CToken Decimals)
      */
     function exchangeRateStoredInternal() virtual internal view returns (uint) {
         uint _totalSupply = totalSupply;


### PR DESCRIPTION
- exchangeRateCurrent()
- exchangeRateStored()
- exchangeRateStoredInternal()